### PR TITLE
Allow basedir to be specified when calling Glob

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.go]
+intent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ func Glob(basedir, pattern string) ([]string, error)
 Glob finds all files and directories in the filesystem that match `pattern` ([see below](#patterns)).
 If pattern is a relative path, it will be searched relative to `basedir`.
 
+### PathGlob
+```go
+func PathGlob(basedir, pattern string) ([]string, error)
+```
+
+PathGlob finds all files and directories in the filesystem that match `pattern` ([see below](#patterns)).
+If pattern is a relative path, it will be searched relative to `basedir`.
+The difference between Glob and PathGlob is that PathGlob will automatically use your system's path separator to split the `pattern`.
+
 ## Patterns
 
 **doublestar** supports the following special terms in the patterns:

--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ PathMatch returns true  if `name` matches the file name `pattern` ([see below](#
 
 ### Glob
 ```go
-func Glob(pattern string) ([]string, error)
+func Glob(basedir, pattern string) ([]string, error)
 ```
 
 Glob finds all files and directories in the filesystem that match `pattern` ([see below](#patterns)).
+If pattern is a relative path, it will be searched relative to `basedir`.
 
 ## Patterns
 

--- a/README.md
+++ b/README.md
@@ -47,22 +47,29 @@ func PathMatch(pattern, name string) (bool, error)
 
 PathMatch returns true  if `name` matches the file name `pattern` ([see below](#patterns)). The difference between Match and PathMatch is that PathMatch will automatically use your system's path separator to split `name` and `pattern`.
 
-### Glob
+### PathGlob
 ```go
-func Glob(basedir, pattern string) ([]string, error)
+func Glob(pattern string) ([]string, error)
 ```
 
 Glob finds all files and directories in the filesystem that match `pattern` ([see below](#patterns)).
+
+### GlobFrom
+```go
+func GlobFrom(basedir, pattern string) ([]string, error)
+```
+
+GlobFrom finds all files and directories in the filesystem that match `pattern` ([see below](#patterns)).
 If pattern is a relative path, it will be searched relative to `basedir`.
 
-### PathGlob
+### PathGlobFrom
 ```go
 func PathGlob(basedir, pattern string) ([]string, error)
 ```
 
-PathGlob finds all files and directories in the filesystem that match `pattern` ([see below](#patterns)).
+PathGlobFrom finds all files and directories in the filesystem that match `pattern` ([see below](#patterns)).
 If pattern is a relative path, it will be searched relative to `basedir`.
-The difference between Glob and PathGlob is that PathGlob will automatically use your system's path separator to split the `pattern`.
+The difference between GlobFrom and PathGlobFrom is that PathGlobFrom will automatically use your system's path separator to split the `pattern`.
 
 ## Patterns
 

--- a/doublestar.go
+++ b/doublestar.go
@@ -1,49 +1,57 @@
 package doublestar
 
 import (
-  "path/filepath"
-  "path"
-  "os"
-  "strings"
-  "unicode/utf8"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
 )
 
 var ErrBadPattern = path.ErrBadPattern
 
 func splitPathOnSeparator(path string, separator rune) []string {
-  // if the separator is '\\', then we can just split...
-  if separator == '\\' { return strings.Split(path, string(separator)) }
+	// if the separator is '\\', then we can just split...
+	if separator == '\\' {
+		return strings.Split(path, string(separator))
+	}
 
-  // otherwise, we need to be careful of situations where the separator was escaped
-  cnt := strings.Count(path, string(separator))
-  if cnt == 0 { return []string{path} }
-  ret := make([]string, cnt + 1)
-  pathlen := len(path)
-  separatorLen := utf8.RuneLen(separator)
-  idx := 0
-  for start := 0; start < pathlen; {
-    end := indexRuneWithEscaping(path[start:], separator)
-    if end == -1 {
-      end = pathlen
-    } else {
-      end += start
-    }
-    ret[idx] = path[start:end]
-    start = end + separatorLen
-    idx++
-  }
-  return ret[:idx]
+	// otherwise, we need to be careful of situations where the separator was escaped
+	cnt := strings.Count(path, string(separator))
+	if cnt == 0 {
+		return []string{path}
+	}
+	ret := make([]string, cnt+1)
+	pathlen := len(path)
+	separatorLen := utf8.RuneLen(separator)
+	idx := 0
+	for start := 0; start < pathlen; {
+		end := indexRuneWithEscaping(path[start:], separator)
+		if end == -1 {
+			end = pathlen
+		} else {
+			end += start
+		}
+		ret[idx] = path[start:end]
+		start = end + separatorLen
+		idx++
+	}
+	return ret[:idx]
 }
 
 func indexRuneWithEscaping(s string, r rune) int {
-  end := strings.IndexRune(s, r)
-  if end == -1 { return -1 }
-  if end > 0 && s[end - 1] == '\\' {
-    start := end + utf8.RuneLen(r)
-    end = indexRuneWithEscaping(s[start:], r)
-    if end != -1 { end += start }
-  }
-  return end
+	end := strings.IndexRune(s, r)
+	if end == -1 {
+		return -1
+	}
+	if end > 0 && s[end-1] == '\\' {
+		start := end + utf8.RuneLen(r)
+		end = indexRuneWithEscaping(s[start:], r)
+		if end != -1 {
+			end += start
+		}
+	}
+	return end
 }
 
 // Match returns true if name matches the shell file name pattern.
@@ -72,7 +80,7 @@ func indexRuneWithEscaping(s string, r rune) int {
 // returned error is ErrBadPattern, when pattern is malformed.
 //
 func Match(pattern, name string) (bool, error) {
-  return matchWithSeparator(pattern, name, '/')
+	return matchWithSeparator(pattern, name, '/')
 }
 
 // PathMatch is like Match except that it uses your system's path separator.
@@ -81,7 +89,7 @@ func Match(pattern, name string) (bool, error) {
 // disabled.
 //
 func PathMatch(pattern, name string) (bool, error) {
-  return matchWithSeparator(pattern, name, os.PathSeparator)
+	return matchWithSeparator(pattern, name, os.PathSeparator)
 }
 
 // Match returns true if name matches the shell file name pattern.
@@ -110,33 +118,41 @@ func PathMatch(pattern, name string) (bool, error) {
 // is malformed.
 //
 func matchWithSeparator(pattern, name string, separator rune) (bool, error) {
-  patternComponents := splitPathOnSeparator(pattern, separator)
-  nameComponents := splitPathOnSeparator(name, separator)
-  return doMatching(patternComponents, nameComponents)
+	patternComponents := splitPathOnSeparator(pattern, separator)
+	nameComponents := splitPathOnSeparator(name, separator)
+	return doMatching(patternComponents, nameComponents)
 }
 
 func doMatching(patternComponents, nameComponents []string) (matched bool, err error) {
-  patternLen, nameLen := len(patternComponents), len(nameComponents)
-  if patternLen == 0 && nameLen == 0 { return true, nil }
-  if patternLen == 0 || nameLen == 0 { return false, nil }
-  patIdx, nameIdx := 0, 0
-  for ; patIdx < patternLen && nameIdx < nameLen; {
-    if patternComponents[patIdx] == "**" {
-      if patIdx++; patIdx >= patternLen { return true, nil }
-      for ; nameIdx < nameLen; nameIdx++ {
-        if m, _ := doMatching(patternComponents[patIdx:], nameComponents[nameIdx:]); m {
-          return true, nil
-        }
-      }
-      return false, nil
-    } else {
-      matched, err = matchComponent(patternComponents[patIdx], nameComponents[nameIdx])
-      if !matched || err != nil { return }
-    }
-    patIdx++
-    nameIdx++
-  }
-  return patIdx >= patternLen && nameIdx >= nameLen, nil
+	patternLen, nameLen := len(patternComponents), len(nameComponents)
+	if patternLen == 0 && nameLen == 0 {
+		return true, nil
+	}
+	if patternLen == 0 || nameLen == 0 {
+		return false, nil
+	}
+	patIdx, nameIdx := 0, 0
+	for patIdx < patternLen && nameIdx < nameLen {
+		if patternComponents[patIdx] == "**" {
+			if patIdx++; patIdx >= patternLen {
+				return true, nil
+			}
+			for ; nameIdx < nameLen; nameIdx++ {
+				if m, _ := doMatching(patternComponents[patIdx:], nameComponents[nameIdx:]); m {
+					return true, nil
+				}
+			}
+			return false, nil
+		} else {
+			matched, err = matchComponent(patternComponents[patIdx], nameComponents[nameIdx])
+			if !matched || err != nil {
+				return
+			}
+		}
+		patIdx++
+		nameIdx++
+	}
+	return patIdx >= patternLen && nameIdx >= nameLen, nil
 }
 
 // Glob returns the names of all files matching pattern or nil
@@ -149,21 +165,22 @@ func doMatching(patternComponents, nameComponents []string) (matched bool, err e
 // is malformed.
 //
 func Glob(basedir, pattern string) (matches []string, err error) {
-  patternComponents := splitPathOnSeparator(pattern, '/')
-  if len(patternComponents) == 0 { return nil, nil }
+	patternComponents := splitPathOnSeparator(pattern, '/')
+	if len(patternComponents) == 0 {
+		return nil, nil
+	}
 
-  // if the first pattern component is blank, the pattern is an absolute path.
-  if patternComponents[0] == "" {
-    return doGlob(string(filepath.Separator), patternComponents, matches)
-  }
-  
-  if basedir == "" {
-    basedir = "."
-  }
-  
-  return doGlob(basedir, patternComponents, matches)
+	// if the first pattern component is blank, the pattern is an absolute path.
+	if patternComponents[0] == "" {
+		return doGlob(string(filepath.Separator), patternComponents, matches)
+	}
+
+	if basedir == "" {
+		basedir = "."
+	}
+
+	return doGlob(basedir, patternComponents, matches)
 }
-
 
 // PathGlob returns the names of all files matching pattern or nil
 // if there is no matching file. The syntax of pattern is the same
@@ -179,186 +196,231 @@ func Glob(basedir, pattern string) (matches []string, err error) {
 // disabled.
 //
 func PathGlob(basedir, pattern string) (matches []string, err error) {
-  patternComponents := splitPathOnSeparator(pattern, filepath.Separator)
-  if len(patternComponents) == 0 { return nil, nil }
+	patternComponents := splitPathOnSeparator(pattern, filepath.Separator)
+	if len(patternComponents) == 0 {
+		return nil, nil
+	}
 
-  // if the first pattern component is blank, the pattern is an absolute path.
-  if patternComponents[0] == "" {
-    return doGlob(string(filepath.Separator), patternComponents, matches)
-  }
-  
-  if basedir == "" {
-    basedir = "."
-  }
-  
-  return doGlob(basedir, patternComponents, matches)
+	// if the first pattern component is blank, the pattern is an absolute path.
+	if patternComponents[0] == "" {
+		return doGlob(string(filepath.Separator), patternComponents, matches)
+	}
+
+	if basedir == "" {
+		basedir = "."
+	}
+
+	return doGlob(basedir, patternComponents, matches)
 }
 
 func doGlob(basedir string, components, matches []string) (m []string, e error) {
-  m = matches
-  e = nil
+	m = matches
+	e = nil
 
-  // figure out how many components we don't need to glob because they're
-  // just straight directory names
-  patLen := len(components)
-  patIdx := 0
-  for ; patIdx < patLen; patIdx++ {
-    if strings.IndexAny(components[patIdx], "*?[{\\") >= 0 { break }
-  }
-  if patIdx > 0 {
-    basedir = filepath.Join(basedir, filepath.Join(components[0:patIdx]...))
-  }
+	// figure out how many components we don't need to glob because they're
+	// just straight directory names
+	patLen := len(components)
+	patIdx := 0
+	for ; patIdx < patLen; patIdx++ {
+		if strings.IndexAny(components[patIdx], "*?[{\\") >= 0 {
+			break
+		}
+	}
+	if patIdx > 0 {
+		basedir = filepath.Join(basedir, filepath.Join(components[0:patIdx]...))
+	}
 
-  // Stat will return an error if the file/directory doesn't exist
-  fi, err := os.Stat(basedir)
-  if err != nil { return }
+	// Stat will return an error if the file/directory doesn't exist
+	fi, err := os.Stat(basedir)
+	if err != nil {
+		return
+	}
 
-  // if there are no more components, we've found a match
-  if patIdx >= patLen {
-    m = append(m, basedir)
-    return
-  }
+	// if there are no more components, we've found a match
+	if patIdx >= patLen {
+		m = append(m, basedir)
+		return
+	}
 
-  // otherwise, we need to check each item in the directory...
-  // so confirm it's a directory first...
-  if !fi.IsDir() { return }
+	// otherwise, we need to check each item in the directory...
+	// so confirm it's a directory first...
+	if !fi.IsDir() {
+		return
+	}
 
-  // read directory
-  dir, err := os.Open(basedir)
-  if err != nil { return }
-  defer dir.Close()
+	// read directory
+	dir, err := os.Open(basedir)
+	if err != nil {
+		return
+	}
+	defer dir.Close()
 
-  files, _ := dir.Readdir(-1)
-  lastComponent := patIdx + 1 >= patLen
-  if components[patIdx] == "**" {
-    // if the current component is a doublestar, we'll try depth-first
-    for _, file := range files {
-      if file.IsDir() {
-        if lastComponent {
-          m = append(m, filepath.Join(basedir, file.Name()))
-        }
-        m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx:], m)
-      } else if lastComponent {
-        // if the pattern's last component is a doublestar, we match filenames, too
-        m = append(m, filepath.Join(basedir, file.Name()))
-      }
-    }
-    if lastComponent { return }
-    patIdx++
-    lastComponent = patIdx + 1 >= patLen
-  }
+	files, _ := dir.Readdir(-1)
+	lastComponent := patIdx+1 >= patLen
+	if components[patIdx] == "**" {
+		// if the current component is a doublestar, we'll try depth-first
+		for _, file := range files {
+			if file.IsDir() {
+				if lastComponent {
+					m = append(m, filepath.Join(basedir, file.Name()))
+				}
+				m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx:], m)
+			} else if lastComponent {
+				// if the pattern's last component is a doublestar, we match filenames, too
+				m = append(m, filepath.Join(basedir, file.Name()))
+			}
+		}
+		if lastComponent {
+			return
+		}
+		patIdx++
+		lastComponent = patIdx+1 >= patLen
+	}
 
-  var match bool
-  for _, file := range files {
-    match, e = matchComponent(components[patIdx], file.Name())
-    if e != nil { return }
-    if match {
-      if lastComponent {
-        m = append(m, filepath.Join(basedir, file.Name()))
-      } else {
-        m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx + 1:], m)
-      }
-    }
-  }
-  return
+	var match bool
+	for _, file := range files {
+		match, e = matchComponent(components[patIdx], file.Name())
+		if e != nil {
+			return
+		}
+		if match {
+			if lastComponent {
+				m = append(m, filepath.Join(basedir, file.Name()))
+			} else {
+				m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx+1:], m)
+			}
+		}
+	}
+	return
 }
 
 func matchComponent(pattern, name string) (bool, error) {
-  patternLen, nameLen := len(pattern), len(name)
-  if patternLen == 0 && nameLen == 0 { return true, nil }
-  if patternLen == 0 { return false, nil }
-  if nameLen == 0 && pattern != "*" { return false, nil }
-  patIdx, nameIdx := 0, 0
-  for ; patIdx < patternLen && nameIdx < nameLen; {
-    patRune, patAdj := utf8.DecodeRuneInString(pattern[patIdx:])
-    nameRune, nameAdj := utf8.DecodeRuneInString(name[nameIdx:])
-    if patRune == '\\' {
-      patIdx += patAdj
-      patRune, patAdj = utf8.DecodeRuneInString(pattern[patIdx:])
-      if patRune == utf8.RuneError {
-        return false, ErrBadPattern
-      } else if patRune == nameRune {
-        patIdx += patAdj
-        nameIdx += nameAdj
-      } else {
-        return false, nil
-      }
-    } else if patRune == '*' {
-      if patIdx += patAdj; patIdx >= patternLen { return true, nil }
-      for ; nameIdx < nameLen; nameIdx += nameAdj {
-        if m, _ := matchComponent(pattern[patIdx:], name[nameIdx:]); m {
-          return true, nil
-        }
-      }
-      return false, nil
-    } else if patRune == '[' {
-      patIdx += patAdj
-      endClass := indexRuneWithEscaping(pattern[patIdx:], ']')
-      if endClass == -1 { return false, ErrBadPattern }
-      endClass += patIdx
-      classRunes := []rune(pattern[patIdx:endClass])
-      classRunesLen := len(classRunes)
-      if classRunesLen > 0 {
-        classIdx := 0
-        matchClass := false
-        if classRunes[0] == '^' { classIdx++ }
-        for classIdx < classRunesLen {
-          low := classRunes[classIdx]
-          if low == '-' { return false, ErrBadPattern }
-          classIdx++
-          if low == '\\' {
-            if classIdx < classRunesLen {
-              low = classRunes[classIdx]
-              classIdx++
-            } else {
-              return false, ErrBadPattern
-            }
-          }
-          high := low
-          if classIdx < classRunesLen && classRunes[classIdx] == '-' {
-            if classIdx++; classIdx >= classRunesLen { return false, ErrBadPattern }
-            high = classRunes[classIdx]
-            if high == '-' { return false, ErrBadPattern }
-            classIdx++
-            if high == '\\' {
-              if classIdx < classRunesLen {
-                high = classRunes[classIdx]
-                classIdx++
-              } else {
-                return false, ErrBadPattern
-              }
-            }
-          }
-          if low <= nameRune && nameRune <= high { matchClass = true }
-        }
-        if matchClass == (classRunes[0] == '^') { return false, nil }
-      } else {
-        return false, ErrBadPattern
-      }
-      patIdx = endClass + 1
-      nameIdx += nameAdj
-    } else if patRune == '{' {
-      patIdx += patAdj
-      endOptions := indexRuneWithEscaping(pattern[patIdx:], '}')
-      if endOptions == -1 { return false, ErrBadPattern }
-      endOptions += patIdx
-      options := splitPathOnSeparator(pattern[patIdx:endOptions], ',')
-      patIdx = endOptions + 1
-      for _, o := range options {
-        m, e := matchComponent(o + pattern[patIdx:], name[nameIdx:])
-        if e != nil { return false, e }
-        if m { return true, nil }
-      }
-      return false, nil
-    } else if patRune == '?' || patRune == nameRune {
-      patIdx += patAdj
-      nameIdx += nameAdj
-    } else {
-      return false, nil
-    }
-  }
-  if patIdx >= patternLen && nameIdx >= nameLen { return true, nil }
-  if nameIdx >= nameLen && pattern[patIdx:] == "*" { return true, nil }
-  return false, nil
+	patternLen, nameLen := len(pattern), len(name)
+	if patternLen == 0 && nameLen == 0 {
+		return true, nil
+	}
+	if patternLen == 0 {
+		return false, nil
+	}
+	if nameLen == 0 && pattern != "*" {
+		return false, nil
+	}
+	patIdx, nameIdx := 0, 0
+	for patIdx < patternLen && nameIdx < nameLen {
+		patRune, patAdj := utf8.DecodeRuneInString(pattern[patIdx:])
+		nameRune, nameAdj := utf8.DecodeRuneInString(name[nameIdx:])
+		if patRune == '\\' {
+			patIdx += patAdj
+			patRune, patAdj = utf8.DecodeRuneInString(pattern[patIdx:])
+			if patRune == utf8.RuneError {
+				return false, ErrBadPattern
+			} else if patRune == nameRune {
+				patIdx += patAdj
+				nameIdx += nameAdj
+			} else {
+				return false, nil
+			}
+		} else if patRune == '*' {
+			if patIdx += patAdj; patIdx >= patternLen {
+				return true, nil
+			}
+			for ; nameIdx < nameLen; nameIdx += nameAdj {
+				if m, _ := matchComponent(pattern[patIdx:], name[nameIdx:]); m {
+					return true, nil
+				}
+			}
+			return false, nil
+		} else if patRune == '[' {
+			patIdx += patAdj
+			endClass := indexRuneWithEscaping(pattern[patIdx:], ']')
+			if endClass == -1 {
+				return false, ErrBadPattern
+			}
+			endClass += patIdx
+			classRunes := []rune(pattern[patIdx:endClass])
+			classRunesLen := len(classRunes)
+			if classRunesLen > 0 {
+				classIdx := 0
+				matchClass := false
+				if classRunes[0] == '^' {
+					classIdx++
+				}
+				for classIdx < classRunesLen {
+					low := classRunes[classIdx]
+					if low == '-' {
+						return false, ErrBadPattern
+					}
+					classIdx++
+					if low == '\\' {
+						if classIdx < classRunesLen {
+							low = classRunes[classIdx]
+							classIdx++
+						} else {
+							return false, ErrBadPattern
+						}
+					}
+					high := low
+					if classIdx < classRunesLen && classRunes[classIdx] == '-' {
+						if classIdx++; classIdx >= classRunesLen {
+							return false, ErrBadPattern
+						}
+						high = classRunes[classIdx]
+						if high == '-' {
+							return false, ErrBadPattern
+						}
+						classIdx++
+						if high == '\\' {
+							if classIdx < classRunesLen {
+								high = classRunes[classIdx]
+								classIdx++
+							} else {
+								return false, ErrBadPattern
+							}
+						}
+					}
+					if low <= nameRune && nameRune <= high {
+						matchClass = true
+					}
+				}
+				if matchClass == (classRunes[0] == '^') {
+					return false, nil
+				}
+			} else {
+				return false, ErrBadPattern
+			}
+			patIdx = endClass + 1
+			nameIdx += nameAdj
+		} else if patRune == '{' {
+			patIdx += patAdj
+			endOptions := indexRuneWithEscaping(pattern[patIdx:], '}')
+			if endOptions == -1 {
+				return false, ErrBadPattern
+			}
+			endOptions += patIdx
+			options := splitPathOnSeparator(pattern[patIdx:endOptions], ',')
+			patIdx = endOptions + 1
+			for _, o := range options {
+				m, e := matchComponent(o+pattern[patIdx:], name[nameIdx:])
+				if e != nil {
+					return false, e
+				}
+				if m {
+					return true, nil
+				}
+			}
+			return false, nil
+		} else if patRune == '?' || patRune == nameRune {
+			patIdx += patAdj
+			nameIdx += nameAdj
+		} else {
+			return false, nil
+		}
+	}
+	if patIdx >= patternLen && nameIdx >= nameLen {
+		return true, nil
+	}
+	if nameIdx >= nameLen && pattern[patIdx:] == "*" {
+		return true, nil
+	}
+	return false, nil
 }
-

--- a/doublestar.go
+++ b/doublestar.go
@@ -152,7 +152,7 @@ func doMatching(patternComponents, nameComponents []string) (matched bool, err e
 // systems where the separator is '\\' (Windows), escaping will be
 // disabled.
 //
-func Glob(pattern string) (matches []string, err error) {
+func Glob(basedir, pattern string) (matches []string, err error) {
   patternComponents := splitPathOnSeparator(pattern, os.PathSeparator)
   if len(patternComponents) == 0 { return nil, nil }
 
@@ -160,7 +160,7 @@ func Glob(pattern string) (matches []string, err error) {
   if patternComponents[0] == "" {
     return doGlob(string(filepath.Separator), patternComponents, matches)
   }
-  return doGlob(".", patternComponents, matches)
+  return doGlob(basedir, patternComponents, matches)
 }
 
 func doGlob(basedir string, components, matches []string) (m []string, e error) {

--- a/doublestar.go
+++ b/doublestar.go
@@ -148,12 +148,38 @@ func doMatching(patternComponents, nameComponents []string) (matched bool, err e
 // The only possible returned error is ErrBadPattern, when pattern
 // is malformed.
 //
+func Glob(basedir, pattern string) (matches []string, err error) {
+  patternComponents := splitPathOnSeparator(pattern, '/')
+  if len(patternComponents) == 0 { return nil, nil }
+
+  // if the first pattern component is blank, the pattern is an absolute path.
+  if patternComponents[0] == "" {
+    return doGlob(string(filepath.Separator), patternComponents, matches)
+  }
+  
+  if basedir == "" {
+    basedir = "."
+  }
+  
+  return doGlob(basedir, patternComponents, matches)
+}
+
+
+// PathGlob returns the names of all files matching pattern or nil
+// if there is no matching file. The syntax of pattern is the same
+// as in PathMatch. The pattern may describe hierarchical names such as
+// /usr/*/bin/ed (assuming the Separator is '/').
+//
+// Glob ignores file system errors such as I/O errors reading directories.
+// The only possible returned error is ErrBadPattern, when pattern
+// is malformed.
+//
 // Your system path separator is automatically used. This means on
 // systems where the separator is '\\' (Windows), escaping will be
 // disabled.
 //
-func Glob(basedir, pattern string) (matches []string, err error) {
-  patternComponents := splitPathOnSeparator(pattern, os.PathSeparator)
+func PathGlob(basedir, pattern string) (matches []string, err error) {
+  patternComponents := splitPathOnSeparator(pattern, filepath.Separator)
   if len(patternComponents) == 0 { return nil, nil }
 
   // if the first pattern component is blank, the pattern is an absolute path.

--- a/doublestar.go
+++ b/doublestar.go
@@ -1,57 +1,57 @@
 package doublestar
 
 import (
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
-	"unicode/utf8"
+  "os"
+  "path"
+  "path/filepath"
+  "strings"
+  "unicode/utf8"
 )
 
 var ErrBadPattern = path.ErrBadPattern
 
 func splitPathOnSeparator(path string, separator rune) []string {
-	// if the separator is '\\', then we can just split...
-	if separator == '\\' {
-		return strings.Split(path, string(separator))
-	}
+  // if the separator is '\\', then we can just split...
+  if separator == '\\' {
+    return strings.Split(path, string(separator))
+  }
 
-	// otherwise, we need to be careful of situations where the separator was escaped
-	cnt := strings.Count(path, string(separator))
-	if cnt == 0 {
-		return []string{path}
-	}
-	ret := make([]string, cnt+1)
-	pathlen := len(path)
-	separatorLen := utf8.RuneLen(separator)
-	idx := 0
-	for start := 0; start < pathlen; {
-		end := indexRuneWithEscaping(path[start:], separator)
-		if end == -1 {
-			end = pathlen
-		} else {
-			end += start
-		}
-		ret[idx] = path[start:end]
-		start = end + separatorLen
-		idx++
-	}
-	return ret[:idx]
+  // otherwise, we need to be careful of situations where the separator was escaped
+  cnt := strings.Count(path, string(separator))
+  if cnt == 0 {
+    return []string{path}
+  }
+  ret := make([]string, cnt+1)
+  pathlen := len(path)
+  separatorLen := utf8.RuneLen(separator)
+  idx := 0
+  for start := 0; start < pathlen; {
+    end := indexRuneWithEscaping(path[start:], separator)
+    if end == -1 {
+      end = pathlen
+    } else {
+      end += start
+    }
+    ret[idx] = path[start:end]
+    start = end + separatorLen
+    idx++
+  }
+  return ret[:idx]
 }
 
 func indexRuneWithEscaping(s string, r rune) int {
-	end := strings.IndexRune(s, r)
-	if end == -1 {
-		return -1
-	}
-	if end > 0 && s[end-1] == '\\' {
-		start := end + utf8.RuneLen(r)
-		end = indexRuneWithEscaping(s[start:], r)
-		if end != -1 {
-			end += start
-		}
-	}
-	return end
+  end := strings.IndexRune(s, r)
+  if end == -1 {
+    return -1
+  }
+  if end > 0 && s[end-1] == '\\' {
+    start := end + utf8.RuneLen(r)
+    end = indexRuneWithEscaping(s[start:], r)
+    if end != -1 {
+      end += start
+    }
+  }
+  return end
 }
 
 // Match returns true if name matches the shell file name pattern.
@@ -80,7 +80,7 @@ func indexRuneWithEscaping(s string, r rune) int {
 // returned error is ErrBadPattern, when pattern is malformed.
 //
 func Match(pattern, name string) (bool, error) {
-	return matchWithSeparator(pattern, name, '/')
+  return matchWithSeparator(pattern, name, '/')
 }
 
 // PathMatch is like Match except that it uses your system's path separator.
@@ -89,7 +89,7 @@ func Match(pattern, name string) (bool, error) {
 // disabled.
 //
 func PathMatch(pattern, name string) (bool, error) {
-	return matchWithSeparator(pattern, name, os.PathSeparator)
+  return matchWithSeparator(pattern, name, os.PathSeparator)
 }
 
 // Match returns true if name matches the shell file name pattern.
@@ -118,41 +118,41 @@ func PathMatch(pattern, name string) (bool, error) {
 // is malformed.
 //
 func matchWithSeparator(pattern, name string, separator rune) (bool, error) {
-	patternComponents := splitPathOnSeparator(pattern, separator)
-	nameComponents := splitPathOnSeparator(name, separator)
-	return doMatching(patternComponents, nameComponents)
+  patternComponents := splitPathOnSeparator(pattern, separator)
+  nameComponents := splitPathOnSeparator(name, separator)
+  return doMatching(patternComponents, nameComponents)
 }
 
 func doMatching(patternComponents, nameComponents []string) (matched bool, err error) {
-	patternLen, nameLen := len(patternComponents), len(nameComponents)
-	if patternLen == 0 && nameLen == 0 {
-		return true, nil
-	}
-	if patternLen == 0 || nameLen == 0 {
-		return false, nil
-	}
-	patIdx, nameIdx := 0, 0
-	for patIdx < patternLen && nameIdx < nameLen {
-		if patternComponents[patIdx] == "**" {
-			if patIdx++; patIdx >= patternLen {
-				return true, nil
-			}
-			for ; nameIdx < nameLen; nameIdx++ {
-				if m, _ := doMatching(patternComponents[patIdx:], nameComponents[nameIdx:]); m {
-					return true, nil
-				}
-			}
-			return false, nil
-		} else {
-			matched, err = matchComponent(patternComponents[patIdx], nameComponents[nameIdx])
-			if !matched || err != nil {
-				return
-			}
-		}
-		patIdx++
-		nameIdx++
-	}
-	return patIdx >= patternLen && nameIdx >= nameLen, nil
+  patternLen, nameLen := len(patternComponents), len(nameComponents)
+  if patternLen == 0 && nameLen == 0 {
+    return true, nil
+  }
+  if patternLen == 0 || nameLen == 0 {
+    return false, nil
+  }
+  patIdx, nameIdx := 0, 0
+  for patIdx < patternLen && nameIdx < nameLen {
+    if patternComponents[patIdx] == "**" {
+      if patIdx++; patIdx >= patternLen {
+        return true, nil
+      }
+      for ; nameIdx < nameLen; nameIdx++ {
+        if m, _ := doMatching(patternComponents[patIdx:], nameComponents[nameIdx:]); m {
+          return true, nil
+        }
+      }
+      return false, nil
+    } else {
+      matched, err = matchComponent(patternComponents[patIdx], nameComponents[nameIdx])
+      if !matched || err != nil {
+        return
+      }
+    }
+    patIdx++
+    nameIdx++
+  }
+  return patIdx >= patternLen && nameIdx >= nameLen, nil
 }
 
 // Glob returns the names of all files matching pattern or nil
@@ -165,21 +165,21 @@ func doMatching(patternComponents, nameComponents []string) (matched bool, err e
 // is malformed.
 //
 func Glob(basedir, pattern string) (matches []string, err error) {
-	patternComponents := splitPathOnSeparator(pattern, '/')
-	if len(patternComponents) == 0 {
-		return nil, nil
-	}
+  patternComponents := splitPathOnSeparator(pattern, '/')
+  if len(patternComponents) == 0 {
+    return nil, nil
+  }
 
-	// if the first pattern component is blank, the pattern is an absolute path.
-	if patternComponents[0] == "" {
-		return doGlob(string(filepath.Separator), patternComponents, matches)
-	}
+  // if the first pattern component is blank, the pattern is an absolute path.
+  if patternComponents[0] == "" {
+    return doGlob(string(filepath.Separator), patternComponents, matches)
+  }
 
-	if basedir == "" {
-		basedir = "."
-	}
+  if basedir == "" {
+    basedir = "."
+  }
 
-	return doGlob(basedir, patternComponents, matches)
+  return doGlob(basedir, patternComponents, matches)
 }
 
 // PathGlob returns the names of all files matching pattern or nil
@@ -196,231 +196,231 @@ func Glob(basedir, pattern string) (matches []string, err error) {
 // disabled.
 //
 func PathGlob(basedir, pattern string) (matches []string, err error) {
-	patternComponents := splitPathOnSeparator(pattern, filepath.Separator)
-	if len(patternComponents) == 0 {
-		return nil, nil
-	}
+  patternComponents := splitPathOnSeparator(pattern, filepath.Separator)
+  if len(patternComponents) == 0 {
+    return nil, nil
+  }
 
-	// if the first pattern component is blank, the pattern is an absolute path.
-	if patternComponents[0] == "" {
-		return doGlob(string(filepath.Separator), patternComponents, matches)
-	}
+  // if the first pattern component is blank, the pattern is an absolute path.
+  if patternComponents[0] == "" {
+    return doGlob(string(filepath.Separator), patternComponents, matches)
+  }
 
-	if basedir == "" {
-		basedir = "."
-	}
+  if basedir == "" {
+    basedir = "."
+  }
 
-	return doGlob(basedir, patternComponents, matches)
+  return doGlob(basedir, patternComponents, matches)
 }
 
 func doGlob(basedir string, components, matches []string) (m []string, e error) {
-	m = matches
-	e = nil
+  m = matches
+  e = nil
 
-	// figure out how many components we don't need to glob because they're
-	// just straight directory names
-	patLen := len(components)
-	patIdx := 0
-	for ; patIdx < patLen; patIdx++ {
-		if strings.IndexAny(components[patIdx], "*?[{\\") >= 0 {
-			break
-		}
-	}
-	if patIdx > 0 {
-		basedir = filepath.Join(basedir, filepath.Join(components[0:patIdx]...))
-	}
+  // figure out how many components we don't need to glob because they're
+  // just straight directory names
+  patLen := len(components)
+  patIdx := 0
+  for ; patIdx < patLen; patIdx++ {
+    if strings.IndexAny(components[patIdx], "*?[{\\") >= 0 {
+      break
+    }
+  }
+  if patIdx > 0 {
+    basedir = filepath.Join(basedir, filepath.Join(components[0:patIdx]...))
+  }
 
-	// Stat will return an error if the file/directory doesn't exist
-	fi, err := os.Stat(basedir)
-	if err != nil {
-		return
-	}
+  // Stat will return an error if the file/directory doesn't exist
+  fi, err := os.Stat(basedir)
+  if err != nil {
+    return
+  }
 
-	// if there are no more components, we've found a match
-	if patIdx >= patLen {
-		m = append(m, basedir)
-		return
-	}
+  // if there are no more components, we've found a match
+  if patIdx >= patLen {
+    m = append(m, basedir)
+    return
+  }
 
-	// otherwise, we need to check each item in the directory...
-	// so confirm it's a directory first...
-	if !fi.IsDir() {
-		return
-	}
+  // otherwise, we need to check each item in the directory...
+  // so confirm it's a directory first...
+  if !fi.IsDir() {
+    return
+  }
 
-	// read directory
-	dir, err := os.Open(basedir)
-	if err != nil {
-		return
-	}
-	defer dir.Close()
+  // read directory
+  dir, err := os.Open(basedir)
+  if err != nil {
+    return
+  }
+  defer dir.Close()
 
-	files, _ := dir.Readdir(-1)
-	lastComponent := patIdx+1 >= patLen
-	if components[patIdx] == "**" {
-		// if the current component is a doublestar, we'll try depth-first
-		for _, file := range files {
-			if file.IsDir() {
-				if lastComponent {
-					m = append(m, filepath.Join(basedir, file.Name()))
-				}
-				m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx:], m)
-			} else if lastComponent {
-				// if the pattern's last component is a doublestar, we match filenames, too
-				m = append(m, filepath.Join(basedir, file.Name()))
-			}
-		}
-		if lastComponent {
-			return
-		}
-		patIdx++
-		lastComponent = patIdx+1 >= patLen
-	}
+  files, _ := dir.Readdir(-1)
+  lastComponent := patIdx+1 >= patLen
+  if components[patIdx] == "**" {
+    // if the current component is a doublestar, we'll try depth-first
+    for _, file := range files {
+      if file.IsDir() {
+        if lastComponent {
+          m = append(m, filepath.Join(basedir, file.Name()))
+        }
+        m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx:], m)
+      } else if lastComponent {
+        // if the pattern's last component is a doublestar, we match filenames, too
+        m = append(m, filepath.Join(basedir, file.Name()))
+      }
+    }
+    if lastComponent {
+      return
+    }
+    patIdx++
+    lastComponent = patIdx+1 >= patLen
+  }
 
-	var match bool
-	for _, file := range files {
-		match, e = matchComponent(components[patIdx], file.Name())
-		if e != nil {
-			return
-		}
-		if match {
-			if lastComponent {
-				m = append(m, filepath.Join(basedir, file.Name()))
-			} else {
-				m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx+1:], m)
-			}
-		}
-	}
-	return
+  var match bool
+  for _, file := range files {
+    match, e = matchComponent(components[patIdx], file.Name())
+    if e != nil {
+      return
+    }
+    if match {
+      if lastComponent {
+        m = append(m, filepath.Join(basedir, file.Name()))
+      } else {
+        m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx+1:], m)
+      }
+    }
+  }
+  return
 }
 
 func matchComponent(pattern, name string) (bool, error) {
-	patternLen, nameLen := len(pattern), len(name)
-	if patternLen == 0 && nameLen == 0 {
-		return true, nil
-	}
-	if patternLen == 0 {
-		return false, nil
-	}
-	if nameLen == 0 && pattern != "*" {
-		return false, nil
-	}
-	patIdx, nameIdx := 0, 0
-	for patIdx < patternLen && nameIdx < nameLen {
-		patRune, patAdj := utf8.DecodeRuneInString(pattern[patIdx:])
-		nameRune, nameAdj := utf8.DecodeRuneInString(name[nameIdx:])
-		if patRune == '\\' {
-			patIdx += patAdj
-			patRune, patAdj = utf8.DecodeRuneInString(pattern[patIdx:])
-			if patRune == utf8.RuneError {
-				return false, ErrBadPattern
-			} else if patRune == nameRune {
-				patIdx += patAdj
-				nameIdx += nameAdj
-			} else {
-				return false, nil
-			}
-		} else if patRune == '*' {
-			if patIdx += patAdj; patIdx >= patternLen {
-				return true, nil
-			}
-			for ; nameIdx < nameLen; nameIdx += nameAdj {
-				if m, _ := matchComponent(pattern[patIdx:], name[nameIdx:]); m {
-					return true, nil
-				}
-			}
-			return false, nil
-		} else if patRune == '[' {
-			patIdx += patAdj
-			endClass := indexRuneWithEscaping(pattern[patIdx:], ']')
-			if endClass == -1 {
-				return false, ErrBadPattern
-			}
-			endClass += patIdx
-			classRunes := []rune(pattern[patIdx:endClass])
-			classRunesLen := len(classRunes)
-			if classRunesLen > 0 {
-				classIdx := 0
-				matchClass := false
-				if classRunes[0] == '^' {
-					classIdx++
-				}
-				for classIdx < classRunesLen {
-					low := classRunes[classIdx]
-					if low == '-' {
-						return false, ErrBadPattern
-					}
-					classIdx++
-					if low == '\\' {
-						if classIdx < classRunesLen {
-							low = classRunes[classIdx]
-							classIdx++
-						} else {
-							return false, ErrBadPattern
-						}
-					}
-					high := low
-					if classIdx < classRunesLen && classRunes[classIdx] == '-' {
-						if classIdx++; classIdx >= classRunesLen {
-							return false, ErrBadPattern
-						}
-						high = classRunes[classIdx]
-						if high == '-' {
-							return false, ErrBadPattern
-						}
-						classIdx++
-						if high == '\\' {
-							if classIdx < classRunesLen {
-								high = classRunes[classIdx]
-								classIdx++
-							} else {
-								return false, ErrBadPattern
-							}
-						}
-					}
-					if low <= nameRune && nameRune <= high {
-						matchClass = true
-					}
-				}
-				if matchClass == (classRunes[0] == '^') {
-					return false, nil
-				}
-			} else {
-				return false, ErrBadPattern
-			}
-			patIdx = endClass + 1
-			nameIdx += nameAdj
-		} else if patRune == '{' {
-			patIdx += patAdj
-			endOptions := indexRuneWithEscaping(pattern[patIdx:], '}')
-			if endOptions == -1 {
-				return false, ErrBadPattern
-			}
-			endOptions += patIdx
-			options := splitPathOnSeparator(pattern[patIdx:endOptions], ',')
-			patIdx = endOptions + 1
-			for _, o := range options {
-				m, e := matchComponent(o+pattern[patIdx:], name[nameIdx:])
-				if e != nil {
-					return false, e
-				}
-				if m {
-					return true, nil
-				}
-			}
-			return false, nil
-		} else if patRune == '?' || patRune == nameRune {
-			patIdx += patAdj
-			nameIdx += nameAdj
-		} else {
-			return false, nil
-		}
-	}
-	if patIdx >= patternLen && nameIdx >= nameLen {
-		return true, nil
-	}
-	if nameIdx >= nameLen && pattern[patIdx:] == "*" {
-		return true, nil
-	}
-	return false, nil
+  patternLen, nameLen := len(pattern), len(name)
+  if patternLen == 0 && nameLen == 0 {
+    return true, nil
+  }
+  if patternLen == 0 {
+    return false, nil
+  }
+  if nameLen == 0 && pattern != "*" {
+    return false, nil
+  }
+  patIdx, nameIdx := 0, 0
+  for patIdx < patternLen && nameIdx < nameLen {
+    patRune, patAdj := utf8.DecodeRuneInString(pattern[patIdx:])
+    nameRune, nameAdj := utf8.DecodeRuneInString(name[nameIdx:])
+    if patRune == '\\' {
+      patIdx += patAdj
+      patRune, patAdj = utf8.DecodeRuneInString(pattern[patIdx:])
+      if patRune == utf8.RuneError {
+        return false, ErrBadPattern
+      } else if patRune == nameRune {
+        patIdx += patAdj
+        nameIdx += nameAdj
+      } else {
+        return false, nil
+      }
+    } else if patRune == '*' {
+      if patIdx += patAdj; patIdx >= patternLen {
+        return true, nil
+      }
+      for ; nameIdx < nameLen; nameIdx += nameAdj {
+        if m, _ := matchComponent(pattern[patIdx:], name[nameIdx:]); m {
+          return true, nil
+        }
+      }
+      return false, nil
+    } else if patRune == '[' {
+      patIdx += patAdj
+      endClass := indexRuneWithEscaping(pattern[patIdx:], ']')
+      if endClass == -1 {
+        return false, ErrBadPattern
+      }
+      endClass += patIdx
+      classRunes := []rune(pattern[patIdx:endClass])
+      classRunesLen := len(classRunes)
+      if classRunesLen > 0 {
+        classIdx := 0
+        matchClass := false
+        if classRunes[0] == '^' {
+          classIdx++
+        }
+        for classIdx < classRunesLen {
+          low := classRunes[classIdx]
+          if low == '-' {
+            return false, ErrBadPattern
+          }
+          classIdx++
+          if low == '\\' {
+            if classIdx < classRunesLen {
+              low = classRunes[classIdx]
+              classIdx++
+            } else {
+              return false, ErrBadPattern
+            }
+          }
+          high := low
+          if classIdx < classRunesLen && classRunes[classIdx] == '-' {
+            if classIdx++; classIdx >= classRunesLen {
+              return false, ErrBadPattern
+            }
+            high = classRunes[classIdx]
+            if high == '-' {
+              return false, ErrBadPattern
+            }
+            classIdx++
+            if high == '\\' {
+              if classIdx < classRunesLen {
+                high = classRunes[classIdx]
+                classIdx++
+              } else {
+                return false, ErrBadPattern
+              }
+            }
+          }
+          if low <= nameRune && nameRune <= high {
+            matchClass = true
+          }
+        }
+        if matchClass == (classRunes[0] == '^') {
+          return false, nil
+        }
+      } else {
+        return false, ErrBadPattern
+      }
+      patIdx = endClass + 1
+      nameIdx += nameAdj
+    } else if patRune == '{' {
+      patIdx += patAdj
+      endOptions := indexRuneWithEscaping(pattern[patIdx:], '}')
+      if endOptions == -1 {
+        return false, ErrBadPattern
+      }
+      endOptions += patIdx
+      options := splitPathOnSeparator(pattern[patIdx:endOptions], ',')
+      patIdx = endOptions + 1
+      for _, o := range options {
+        m, e := matchComponent(o+pattern[patIdx:], name[nameIdx:])
+        if e != nil {
+          return false, e
+        }
+        if m {
+          return true, nil
+        }
+      }
+      return false, nil
+    } else if patRune == '?' || patRune == nameRune {
+      patIdx += patAdj
+      nameIdx += nameAdj
+    } else {
+      return false, nil
+    }
+  }
+  if patIdx >= patternLen && nameIdx >= nameLen {
+    return true, nil
+  }
+  if nameIdx >= nameLen && pattern[patIdx:] == "*" {
+    return true, nil
+  }
+  return false, nil
 }

--- a/doublestar.go
+++ b/doublestar.go
@@ -155,6 +155,7 @@ func doMatching(patternComponents, nameComponents []string) (matched bool, err e
   return patIdx >= patternLen && nameIdx >= nameLen, nil
 }
 
+
 // Glob returns the names of all files matching pattern or nil
 // if there is no matching file. The syntax of pattern is the same
 // as in Match. The pattern may describe hierarchical names such as
@@ -164,7 +165,30 @@ func doMatching(patternComponents, nameComponents []string) (matched bool, err e
 // The only possible returned error is ErrBadPattern, when pattern
 // is malformed.
 //
-func Glob(basedir, pattern string) (matches []string, err error) {
+func Glob(pattern string) (matches []string, err error) {
+  patternComponents := splitPathOnSeparator(pattern, filepath.Separator)
+  if len(patternComponents) == 0 {
+    return nil, nil
+  }
+
+  // if the first pattern component is blank, the pattern is an absolute path.
+  if patternComponents[0] == "" {
+    return doGlob(string(filepath.Separator), patternComponents, matches)
+  }
+
+  return doGlob(".", patternComponents, matches)
+}
+
+// GlobFrom returns the names of all files matching pattern or nil
+// if there is no matching file. The syntax of pattern is the same
+// as in Match. The pattern may describe hierarchical names such as
+// /usr/*/bin/ed (assuming the Separator is '/').
+//
+// GlobFrom ignores file system errors such as I/O errors reading directories.
+// The only possible returned error is ErrBadPattern, when pattern
+// is malformed.
+//
+func GlobFrom(basedir, pattern string) (matches []string, err error) {
   patternComponents := splitPathOnSeparator(pattern, '/')
   if len(patternComponents) == 0 {
     return nil, nil
@@ -182,7 +206,7 @@ func Glob(basedir, pattern string) (matches []string, err error) {
   return doGlob(basedir, patternComponents, matches)
 }
 
-// PathGlob returns the names of all files matching pattern or nil
+// PathGlobFrom returns the names of all files matching pattern or nil
 // if there is no matching file. The syntax of pattern is the same
 // as in PathMatch. The pattern may describe hierarchical names such as
 // /usr/*/bin/ed (assuming the Separator is '/').
@@ -195,7 +219,7 @@ func Glob(basedir, pattern string) (matches []string, err error) {
 // systems where the separator is '\\' (Windows), escaping will be
 // disabled.
 //
-func PathGlob(basedir, pattern string) (matches []string, err error) {
+func PathGlobFrom(basedir, pattern string) (matches []string, err error) {
   patternComponents := splitPathOnSeparator(pattern, filepath.Separator)
   if len(patternComponents) == 0 {
     return nil, nil

--- a/doublestar.go
+++ b/doublestar.go
@@ -160,6 +160,11 @@ func Glob(basedir, pattern string) (matches []string, err error) {
   if patternComponents[0] == "" {
     return doGlob(string(filepath.Separator), patternComponents, matches)
   }
+  
+  if basedir == "" {
+    basedir = "."
+  }
+  
   return doGlob(basedir, patternComponents, matches)
 }
 

--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -122,7 +122,7 @@ func testGlobWith(t *testing.T, idx int, tt MatchTest) {
     }
   }()
 
-  matches, err := Glob(".", "test/"+tt.pattern)
+  matches, err := GlobFrom(".", "test/"+tt.pattern)
   if inSlice(filepath.FromSlash("test/"+tt.s), matches) != tt.match {
     if tt.match {
       t.Errorf("#%v. Glob(%#q) = %#v - doesn't contain %v, but should", idx, tt.pattern, matches, tt.s)

--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -2,7 +2,11 @@
 
 package doublestar
 
-import "testing"
+import (
+  "testing"
+  "path/filepath"
+)
+  
 
 type MatchTest struct {
   pattern, s string
@@ -120,7 +124,7 @@ func testGlobWith(t *testing.T, idx int, tt MatchTest) {
   }()
 
   matches, err := Glob(".", "test/" + tt.pattern)
-  if inSlice("test/" + tt.s, matches) != tt.match {
+  if inSlice(filepath.FromSlash("test/" + tt.s), matches) != tt.match {
     if tt.match {
       t.Errorf("#%v. Glob(%#q) = %#v - doesn't contain %v, but should", idx, tt.pattern, matches, tt.s)
     } else {

--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -3,143 +3,143 @@
 package doublestar
 
 import (
-  "testing"
-  "path/filepath"
+	"path/filepath"
+	"testing"
 )
-  
 
 type MatchTest struct {
-  pattern, s string
-  match      bool
-  err        error
-  testGlob   bool
+	pattern, s string
+	match      bool
+	err        error
+	testGlob   bool
 }
 
 var matchTests = []MatchTest{
-  {"abc", "abc", true, nil, true},
-  {"*", "abc", true, nil, true},
-  {"*c", "abc", true, nil, true},
-  {"a*", "a", true, nil, true},
-  {"a*", "abc", true, nil, true},
-  {"a*", "ab/c", false, nil, true},
-  {"a*/b", "abc/b", true, nil, true},
-  {"a*/b", "a/c/b", false, nil, true},
-  {"a*b*c*d*e*/f", "axbxcxdxe/f", true, nil, true},
-  {"a*b*c*d*e*/f", "axbxcxdxexxx/f", true, nil, true},
-  {"a*b*c*d*e*/f", "axbxcxdxe/xxx/f", false, nil, true},
-  {"a*b*c*d*e*/f", "axbxcxdxexxx/fff", false, nil, true},
-  {"a*b?c*x", "abxbbxdbxebxczzx", true, nil, true},
-  {"a*b?c*x", "abxbbxdbxebxczzy", false, nil, true},
-  {"ab[c]", "abc", true, nil, true},
-  {"ab[b-d]", "abc", true, nil, true},
-  {"ab[e-g]", "abc", false, nil, true},
-  {"ab[^c]", "abc", false, nil, true},
-  {"ab[^b-d]", "abc", false, nil, true},
-  {"ab[^e-g]", "abc", true, nil, true},
-  {"a\\*b", "a*b", true, nil, true},
-  {"a\\*b", "ab", false, nil, true},
-  {"a?b", "a☺b", true, nil, true},
-  {"a[^a]b", "a☺b", true, nil, true},
-  {"a???b", "a☺b", false, nil, true},
-  {"a[^a][^a][^a]b", "a☺b", false, nil, true},
-  {"[a-ζ]*", "α", true, nil, true},
-  {"*[a-ζ]", "A", false, nil, true},
-  {"a?b", "a/b", false, nil, true},
-  {"a*b", "a/b", false, nil, true},
-  {"[\\]a]", "]", true, nil, true},
-  {"[\\-]", "-", true, nil, true},
-  {"[x\\-]", "x", true, nil, true},
-  {"[x\\-]", "-", true, nil, true},
-  {"[x\\-]", "z", false, nil, true},
-  {"[\\-x]", "x", true, nil, true},
-  {"[\\-x]", "-", true, nil, true},
-  {"[\\-x]", "a", false, nil, true},
-  {"[]a]", "]", false, ErrBadPattern, true},
-  {"[-]", "-", false, ErrBadPattern, true},
-  {"[x-]", "x", false, ErrBadPattern, true},
-  {"[x-]", "-", false, ErrBadPattern, true},
-  {"[x-]", "z", false, ErrBadPattern, true},
-  {"[-x]", "x", false, ErrBadPattern, true},
-  {"[-x]", "-", false, ErrBadPattern, true},
-  {"[-x]", "a", false, ErrBadPattern, true},
-  {"\\", "a", false, ErrBadPattern, true},
-  {"[a-b-c]", "a", false, ErrBadPattern, true},
-  {"[", "a", false, ErrBadPattern, true},
-  {"[^", "a", false, ErrBadPattern, true},
-  {"[^bc", "a", false, ErrBadPattern, true},
-  {"a[", "a", false, nil, false},
-  {"a[", "ab", false, ErrBadPattern, true},
-  {"*x", "xxx", true, nil, true},
-  {"a/**", "a", false, nil, true},
-  {"a/**", "a/b", true, nil, true},
-  {"a/**", "a/b/c", true, nil, true},
-  {"**/c", "c", true, nil, true},
-  {"**/c", "b/c", true, nil, true},
-  {"**/c", "a/b/c", true, nil, true},
-  {"**/c", "a/b", false, nil, true},
-  {"**/c", "abcd", false, nil, true},
-  {"**/c", "a/abc", false, nil, true},
-  {"a/**/b", "a/b", true, nil, true},
-  {"a/**/c", "a/b/c", true, nil, true},
-  {"a/**/d", "a/b/c/d", true, nil, true},
-  {"a/\\**", "a/b/c", false, nil, true},
-  {"a/\\**", "a/*", true, nil, true},
-  {"ab{c,d}", "abc", true, nil, true},
-  {"ab{c,d,*}", "abcde", true, nil, true},
-  {"ab{c,d}[", "abcd", false, ErrBadPattern, true},
+	{"abc", "abc", true, nil, true},
+	{"*", "abc", true, nil, true},
+	{"*c", "abc", true, nil, true},
+	{"a*", "a", true, nil, true},
+	{"a*", "abc", true, nil, true},
+	{"a*", "ab/c", false, nil, true},
+	{"a*/b", "abc/b", true, nil, true},
+	{"a*/b", "a/c/b", false, nil, true},
+	{"a*b*c*d*e*/f", "axbxcxdxe/f", true, nil, true},
+	{"a*b*c*d*e*/f", "axbxcxdxexxx/f", true, nil, true},
+	{"a*b*c*d*e*/f", "axbxcxdxe/xxx/f", false, nil, true},
+	{"a*b*c*d*e*/f", "axbxcxdxexxx/fff", false, nil, true},
+	{"a*b?c*x", "abxbbxdbxebxczzx", true, nil, true},
+	{"a*b?c*x", "abxbbxdbxebxczzy", false, nil, true},
+	{"ab[c]", "abc", true, nil, true},
+	{"ab[b-d]", "abc", true, nil, true},
+	{"ab[e-g]", "abc", false, nil, true},
+	{"ab[^c]", "abc", false, nil, true},
+	{"ab[^b-d]", "abc", false, nil, true},
+	{"ab[^e-g]", "abc", true, nil, true},
+	{"a\\*b", "a*b", true, nil, true},
+	{"a\\*b", "ab", false, nil, true},
+	{"a?b", "a☺b", true, nil, true},
+	{"a[^a]b", "a☺b", true, nil, true},
+	{"a???b", "a☺b", false, nil, true},
+	{"a[^a][^a][^a]b", "a☺b", false, nil, true},
+	{"[a-ζ]*", "α", true, nil, true},
+	{"*[a-ζ]", "A", false, nil, true},
+	{"a?b", "a/b", false, nil, true},
+	{"a*b", "a/b", false, nil, true},
+	{"[\\]a]", "]", true, nil, true},
+	{"[\\-]", "-", true, nil, true},
+	{"[x\\-]", "x", true, nil, true},
+	{"[x\\-]", "-", true, nil, true},
+	{"[x\\-]", "z", false, nil, true},
+	{"[\\-x]", "x", true, nil, true},
+	{"[\\-x]", "-", true, nil, true},
+	{"[\\-x]", "a", false, nil, true},
+	{"[]a]", "]", false, ErrBadPattern, true},
+	{"[-]", "-", false, ErrBadPattern, true},
+	{"[x-]", "x", false, ErrBadPattern, true},
+	{"[x-]", "-", false, ErrBadPattern, true},
+	{"[x-]", "z", false, ErrBadPattern, true},
+	{"[-x]", "x", false, ErrBadPattern, true},
+	{"[-x]", "-", false, ErrBadPattern, true},
+	{"[-x]", "a", false, ErrBadPattern, true},
+	{"\\", "a", false, ErrBadPattern, true},
+	{"[a-b-c]", "a", false, ErrBadPattern, true},
+	{"[", "a", false, ErrBadPattern, true},
+	{"[^", "a", false, ErrBadPattern, true},
+	{"[^bc", "a", false, ErrBadPattern, true},
+	{"a[", "a", false, nil, false},
+	{"a[", "ab", false, ErrBadPattern, true},
+	{"*x", "xxx", true, nil, true},
+	{"a/**", "a", false, nil, true},
+	{"a/**", "a/b", true, nil, true},
+	{"a/**", "a/b/c", true, nil, true},
+	{"**/c", "c", true, nil, true},
+	{"**/c", "b/c", true, nil, true},
+	{"**/c", "a/b/c", true, nil, true},
+	{"**/c", "a/b", false, nil, true},
+	{"**/c", "abcd", false, nil, true},
+	{"**/c", "a/abc", false, nil, true},
+	{"a/**/b", "a/b", true, nil, true},
+	{"a/**/c", "a/b/c", true, nil, true},
+	{"a/**/d", "a/b/c/d", true, nil, true},
+	{"a/\\**", "a/b/c", false, nil, true},
+	{"a/\\**", "a/*", true, nil, true},
+	{"ab{c,d}", "abc", true, nil, true},
+	{"ab{c,d,*}", "abcde", true, nil, true},
+	{"ab{c,d}[", "abcd", false, ErrBadPattern, true},
 }
 
 func TestMatch(t *testing.T) {
-  for idx, tt := range matchTests {
-    testMatchWith(t, idx, tt)
-  }
+	for idx, tt := range matchTests {
+		testMatchWith(t, idx, tt)
+	}
 }
 
 func testMatchWith(t *testing.T, idx int, tt MatchTest) {
-  defer func() {
-    if r := recover(); r != nil {
-      t.Errorf("#%v. Match(%#q, %#q) panicked: %#v", idx, tt.pattern, tt.s, r)
-    }
-  }()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("#%v. Match(%#q, %#q) panicked: %#v", idx, tt.pattern, tt.s, r)
+		}
+	}()
 
-  ok, err := Match(tt.pattern, tt.s)
-  if ok != tt.match || err != tt.err {
-    t.Errorf("#%v. Match(%#q, %#q) = %v, %v want %v, %v", idx, tt.pattern, tt.s, ok, err, tt.match, tt.err)
-  }
+	ok, err := Match(tt.pattern, tt.s)
+	if ok != tt.match || err != tt.err {
+		t.Errorf("#%v. Match(%#q, %#q) = %v, %v want %v, %v", idx, tt.pattern, tt.s, ok, err, tt.match, tt.err)
+	}
 }
 
 func TestGlob(t *testing.T) {
-  for idx, tt := range matchTests {
-    if tt.testGlob {
-      testGlobWith(t, idx, tt)
-    }
-  }
+	for idx, tt := range matchTests {
+		if tt.testGlob {
+			testGlobWith(t, idx, tt)
+		}
+	}
 }
 
 func testGlobWith(t *testing.T, idx int, tt MatchTest) {
-  defer func() {
-    if r := recover(); r != nil {
-      t.Errorf("#%v. Glob(%#q) panicked: %#v", idx, tt.pattern, r)
-    }
-  }()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("#%v. Glob(%#q) panicked: %#v", idx, tt.pattern, r)
+		}
+	}()
 
-  matches, err := Glob(".", "test/" + tt.pattern)
-  if inSlice(filepath.FromSlash("test/" + tt.s), matches) != tt.match {
-    if tt.match {
-      t.Errorf("#%v. Glob(%#q) = %#v - doesn't contain %v, but should", idx, tt.pattern, matches, tt.s)
-    } else {
-      t.Errorf("#%v. Glob(%#q) = %#v - contains %v, but shouldn't", idx, tt.pattern, matches, tt.s)
-    }
-  }
-  if err != tt.err {
-    t.Errorf("#%v. Glob(%#q) has error %v, but should be %v", idx, tt.pattern, err, tt.err)
-  }
+	matches, err := Glob(".", "test/"+tt.pattern)
+	if inSlice(filepath.FromSlash("test/"+tt.s), matches) != tt.match {
+		if tt.match {
+			t.Errorf("#%v. Glob(%#q) = %#v - doesn't contain %v, but should", idx, tt.pattern, matches, tt.s)
+		} else {
+			t.Errorf("#%v. Glob(%#q) = %#v - contains %v, but shouldn't", idx, tt.pattern, matches, tt.s)
+		}
+	}
+	if err != tt.err {
+		t.Errorf("#%v. Glob(%#q) has error %v, but should be %v", idx, tt.pattern, err, tt.err)
+	}
 }
 
 func inSlice(s string, a []string) bool {
-  for _, i := range a {
-    if i == s { return true }
-  }
-  return false
+	for _, i := range a {
+		if i == s {
+			return true
+		}
+	}
+	return false
 }
-

--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -119,7 +119,7 @@ func testGlobWith(t *testing.T, idx int, tt MatchTest) {
     }
   }()
 
-  matches, err := Glob("test/" + tt.pattern)
+  matches, err := Glob(".", "test/" + tt.pattern)
   if inSlice("test/" + tt.s, matches) != tt.match {
     if tt.match {
       t.Errorf("#%v. Glob(%#q) = %#v - doesn't contain %v, but should", idx, tt.pattern, matches, tt.s)

--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -3,143 +3,143 @@
 package doublestar
 
 import (
-	"path/filepath"
-	"testing"
+  "path/filepath"
+  "testing"
 )
 
 type MatchTest struct {
-	pattern, s string
-	match      bool
-	err        error
-	testGlob   bool
+  pattern, s string
+  match      bool
+  err        error
+  testGlob   bool
 }
 
 var matchTests = []MatchTest{
-	{"abc", "abc", true, nil, true},
-	{"*", "abc", true, nil, true},
-	{"*c", "abc", true, nil, true},
-	{"a*", "a", true, nil, true},
-	{"a*", "abc", true, nil, true},
-	{"a*", "ab/c", false, nil, true},
-	{"a*/b", "abc/b", true, nil, true},
-	{"a*/b", "a/c/b", false, nil, true},
-	{"a*b*c*d*e*/f", "axbxcxdxe/f", true, nil, true},
-	{"a*b*c*d*e*/f", "axbxcxdxexxx/f", true, nil, true},
-	{"a*b*c*d*e*/f", "axbxcxdxe/xxx/f", false, nil, true},
-	{"a*b*c*d*e*/f", "axbxcxdxexxx/fff", false, nil, true},
-	{"a*b?c*x", "abxbbxdbxebxczzx", true, nil, true},
-	{"a*b?c*x", "abxbbxdbxebxczzy", false, nil, true},
-	{"ab[c]", "abc", true, nil, true},
-	{"ab[b-d]", "abc", true, nil, true},
-	{"ab[e-g]", "abc", false, nil, true},
-	{"ab[^c]", "abc", false, nil, true},
-	{"ab[^b-d]", "abc", false, nil, true},
-	{"ab[^e-g]", "abc", true, nil, true},
-	{"a\\*b", "a*b", true, nil, true},
-	{"a\\*b", "ab", false, nil, true},
-	{"a?b", "a☺b", true, nil, true},
-	{"a[^a]b", "a☺b", true, nil, true},
-	{"a???b", "a☺b", false, nil, true},
-	{"a[^a][^a][^a]b", "a☺b", false, nil, true},
-	{"[a-ζ]*", "α", true, nil, true},
-	{"*[a-ζ]", "A", false, nil, true},
-	{"a?b", "a/b", false, nil, true},
-	{"a*b", "a/b", false, nil, true},
-	{"[\\]a]", "]", true, nil, true},
-	{"[\\-]", "-", true, nil, true},
-	{"[x\\-]", "x", true, nil, true},
-	{"[x\\-]", "-", true, nil, true},
-	{"[x\\-]", "z", false, nil, true},
-	{"[\\-x]", "x", true, nil, true},
-	{"[\\-x]", "-", true, nil, true},
-	{"[\\-x]", "a", false, nil, true},
-	{"[]a]", "]", false, ErrBadPattern, true},
-	{"[-]", "-", false, ErrBadPattern, true},
-	{"[x-]", "x", false, ErrBadPattern, true},
-	{"[x-]", "-", false, ErrBadPattern, true},
-	{"[x-]", "z", false, ErrBadPattern, true},
-	{"[-x]", "x", false, ErrBadPattern, true},
-	{"[-x]", "-", false, ErrBadPattern, true},
-	{"[-x]", "a", false, ErrBadPattern, true},
-	{"\\", "a", false, ErrBadPattern, true},
-	{"[a-b-c]", "a", false, ErrBadPattern, true},
-	{"[", "a", false, ErrBadPattern, true},
-	{"[^", "a", false, ErrBadPattern, true},
-	{"[^bc", "a", false, ErrBadPattern, true},
-	{"a[", "a", false, nil, false},
-	{"a[", "ab", false, ErrBadPattern, true},
-	{"*x", "xxx", true, nil, true},
-	{"a/**", "a", false, nil, true},
-	{"a/**", "a/b", true, nil, true},
-	{"a/**", "a/b/c", true, nil, true},
-	{"**/c", "c", true, nil, true},
-	{"**/c", "b/c", true, nil, true},
-	{"**/c", "a/b/c", true, nil, true},
-	{"**/c", "a/b", false, nil, true},
-	{"**/c", "abcd", false, nil, true},
-	{"**/c", "a/abc", false, nil, true},
-	{"a/**/b", "a/b", true, nil, true},
-	{"a/**/c", "a/b/c", true, nil, true},
-	{"a/**/d", "a/b/c/d", true, nil, true},
-	{"a/\\**", "a/b/c", false, nil, true},
-	{"a/\\**", "a/*", true, nil, true},
-	{"ab{c,d}", "abc", true, nil, true},
-	{"ab{c,d,*}", "abcde", true, nil, true},
-	{"ab{c,d}[", "abcd", false, ErrBadPattern, true},
+  {"abc", "abc", true, nil, true},
+  {"*", "abc", true, nil, true},
+  {"*c", "abc", true, nil, true},
+  {"a*", "a", true, nil, true},
+  {"a*", "abc", true, nil, true},
+  {"a*", "ab/c", false, nil, true},
+  {"a*/b", "abc/b", true, nil, true},
+  {"a*/b", "a/c/b", false, nil, true},
+  {"a*b*c*d*e*/f", "axbxcxdxe/f", true, nil, true},
+  {"a*b*c*d*e*/f", "axbxcxdxexxx/f", true, nil, true},
+  {"a*b*c*d*e*/f", "axbxcxdxe/xxx/f", false, nil, true},
+  {"a*b*c*d*e*/f", "axbxcxdxexxx/fff", false, nil, true},
+  {"a*b?c*x", "abxbbxdbxebxczzx", true, nil, true},
+  {"a*b?c*x", "abxbbxdbxebxczzy", false, nil, true},
+  {"ab[c]", "abc", true, nil, true},
+  {"ab[b-d]", "abc", true, nil, true},
+  {"ab[e-g]", "abc", false, nil, true},
+  {"ab[^c]", "abc", false, nil, true},
+  {"ab[^b-d]", "abc", false, nil, true},
+  {"ab[^e-g]", "abc", true, nil, true},
+  {"a\\*b", "a*b", true, nil, true},
+  {"a\\*b", "ab", false, nil, true},
+  {"a?b", "a☺b", true, nil, true},
+  {"a[^a]b", "a☺b", true, nil, true},
+  {"a???b", "a☺b", false, nil, true},
+  {"a[^a][^a][^a]b", "a☺b", false, nil, true},
+  {"[a-ζ]*", "α", true, nil, true},
+  {"*[a-ζ]", "A", false, nil, true},
+  {"a?b", "a/b", false, nil, true},
+  {"a*b", "a/b", false, nil, true},
+  {"[\\]a]", "]", true, nil, true},
+  {"[\\-]", "-", true, nil, true},
+  {"[x\\-]", "x", true, nil, true},
+  {"[x\\-]", "-", true, nil, true},
+  {"[x\\-]", "z", false, nil, true},
+  {"[\\-x]", "x", true, nil, true},
+  {"[\\-x]", "-", true, nil, true},
+  {"[\\-x]", "a", false, nil, true},
+  {"[]a]", "]", false, ErrBadPattern, true},
+  {"[-]", "-", false, ErrBadPattern, true},
+  {"[x-]", "x", false, ErrBadPattern, true},
+  {"[x-]", "-", false, ErrBadPattern, true},
+  {"[x-]", "z", false, ErrBadPattern, true},
+  {"[-x]", "x", false, ErrBadPattern, true},
+  {"[-x]", "-", false, ErrBadPattern, true},
+  {"[-x]", "a", false, ErrBadPattern, true},
+  {"\\", "a", false, ErrBadPattern, true},
+  {"[a-b-c]", "a", false, ErrBadPattern, true},
+  {"[", "a", false, ErrBadPattern, true},
+  {"[^", "a", false, ErrBadPattern, true},
+  {"[^bc", "a", false, ErrBadPattern, true},
+  {"a[", "a", false, nil, false},
+  {"a[", "ab", false, ErrBadPattern, true},
+  {"*x", "xxx", true, nil, true},
+  {"a/**", "a", false, nil, true},
+  {"a/**", "a/b", true, nil, true},
+  {"a/**", "a/b/c", true, nil, true},
+  {"**/c", "c", true, nil, true},
+  {"**/c", "b/c", true, nil, true},
+  {"**/c", "a/b/c", true, nil, true},
+  {"**/c", "a/b", false, nil, true},
+  {"**/c", "abcd", false, nil, true},
+  {"**/c", "a/abc", false, nil, true},
+  {"a/**/b", "a/b", true, nil, true},
+  {"a/**/c", "a/b/c", true, nil, true},
+  {"a/**/d", "a/b/c/d", true, nil, true},
+  {"a/\\**", "a/b/c", false, nil, true},
+  {"a/\\**", "a/*", true, nil, true},
+  {"ab{c,d}", "abc", true, nil, true},
+  {"ab{c,d,*}", "abcde", true, nil, true},
+  {"ab{c,d}[", "abcd", false, ErrBadPattern, true},
 }
 
 func TestMatch(t *testing.T) {
-	for idx, tt := range matchTests {
-		testMatchWith(t, idx, tt)
-	}
+  for idx, tt := range matchTests {
+    testMatchWith(t, idx, tt)
+  }
 }
 
 func testMatchWith(t *testing.T, idx int, tt MatchTest) {
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("#%v. Match(%#q, %#q) panicked: %#v", idx, tt.pattern, tt.s, r)
-		}
-	}()
+  defer func() {
+    if r := recover(); r != nil {
+      t.Errorf("#%v. Match(%#q, %#q) panicked: %#v", idx, tt.pattern, tt.s, r)
+    }
+  }()
 
-	ok, err := Match(tt.pattern, tt.s)
-	if ok != tt.match || err != tt.err {
-		t.Errorf("#%v. Match(%#q, %#q) = %v, %v want %v, %v", idx, tt.pattern, tt.s, ok, err, tt.match, tt.err)
-	}
+  ok, err := Match(tt.pattern, tt.s)
+  if ok != tt.match || err != tt.err {
+    t.Errorf("#%v. Match(%#q, %#q) = %v, %v want %v, %v", idx, tt.pattern, tt.s, ok, err, tt.match, tt.err)
+  }
 }
 
 func TestGlob(t *testing.T) {
-	for idx, tt := range matchTests {
-		if tt.testGlob {
-			testGlobWith(t, idx, tt)
-		}
-	}
+  for idx, tt := range matchTests {
+    if tt.testGlob {
+      testGlobWith(t, idx, tt)
+    }
+  }
 }
 
 func testGlobWith(t *testing.T, idx int, tt MatchTest) {
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("#%v. Glob(%#q) panicked: %#v", idx, tt.pattern, r)
-		}
-	}()
+  defer func() {
+    if r := recover(); r != nil {
+      t.Errorf("#%v. Glob(%#q) panicked: %#v", idx, tt.pattern, r)
+    }
+  }()
 
-	matches, err := Glob(".", "test/"+tt.pattern)
-	if inSlice(filepath.FromSlash("test/"+tt.s), matches) != tt.match {
-		if tt.match {
-			t.Errorf("#%v. Glob(%#q) = %#v - doesn't contain %v, but should", idx, tt.pattern, matches, tt.s)
-		} else {
-			t.Errorf("#%v. Glob(%#q) = %#v - contains %v, but shouldn't", idx, tt.pattern, matches, tt.s)
-		}
-	}
-	if err != tt.err {
-		t.Errorf("#%v. Glob(%#q) has error %v, but should be %v", idx, tt.pattern, err, tt.err)
-	}
+  matches, err := Glob(".", "test/"+tt.pattern)
+  if inSlice(filepath.FromSlash("test/"+tt.s), matches) != tt.match {
+    if tt.match {
+      t.Errorf("#%v. Glob(%#q) = %#v - doesn't contain %v, but should", idx, tt.pattern, matches, tt.s)
+    } else {
+      t.Errorf("#%v. Glob(%#q) = %#v - contains %v, but shouldn't", idx, tt.pattern, matches, tt.s)
+    }
+  }
+  if err != tt.err {
+    t.Errorf("#%v. Glob(%#q) has error %v, but should be %v", idx, tt.pattern, err, tt.err)
+  }
 }
 
 func inSlice(s string, a []string) bool {
-	for _, i := range a {
-		if i == s {
-			return true
-		}
-	}
-	return false
+  for _, i := range a {
+    if i == s {
+      return true
+    }
+  }
+  return false
 }


### PR DESCRIPTION
The current glob implementation works well for most situations, however there are instances where the application's current directory doesn't represent the root at which you would like to start globbing, and manually building up a glob expression which includes the directory can be problematic.

This PR solves the issue by requiring the consumer to provide the base directory they wish to perform the glob relative to - it will be used if the glob expression is determined to be relative, falling back on using the root ('/' or '\\') if an absolute path is specified in the glob expression.

This change was necessary to support our use case in [GitLab CI's build runner](https://gitlab.com/gitlab-org/gitlab-ci-multi-runner) in conjunction with [Thargo](https://github.com/EMSSConsulting/Thargo).