### PR TITLE
Support glob'ing symlinks to missing targets

### DIFF
--- a/doublestar.go
+++ b/doublestar.go
@@ -179,7 +179,7 @@ func doGlob(basedir string, components, matches []string) (m []string, e error) 
   }
 
   // Stat will return an error if the file/directory doesn't exist
-  fi, err := os.Stat(basedir)
+  fi, err := os.Lstat(basedir)
   if err != nil { return }
 
   // if there are no more components, we've found a match

--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -83,6 +83,7 @@ var matchTests = []MatchTest{
   {"ab{c,d}[", "abcd", false, ErrBadPattern, true},
   {"abc**", "abc", true, nil, true},
   {"**abc", "abc", true, nil, true},
+  {"broken-symlink", "broken-symlink", true, nil, true},
 }
 
 func TestMatch(t *testing.T) {

--- a/test/broken-symlink
+++ b/test/broken-symlink
@@ -1,0 +1,1 @@
+/tmp/nonexistant-file-20160902155705


### PR DESCRIPTION
Hello - we ran into a situation where a symlink to a non-existant target was not being included in a glob path. Solution was to switch to `os.Lstat` which just doesn't attempt to follow symlinks (and treats regular files just as `Stat` did). Hope you'd consider merging.

Thanks for the library!