### PR TITLE
Support symlinks matching ** token

### DIFF
--- a/doublestar.go
+++ b/doublestar.go
@@ -208,6 +208,12 @@ func doGlob(basedir string, components, matches []string) (m []string, e error) 
   if components[patIdx] == "**" {
     // if the current component is a doublestar, we'll try depth-first
     for _, file := range files {
+      // if symlink, we may want to follow
+      if file.Mode() & os.ModeSymlink != 0 {
+        file, err = os.Stat(filepath.Join(basedir, file.Name()))
+        if err != nil { continue }
+      }
+
       if file.IsDir() {
         if lastComponent {
           m = append(m, filepath.Join(basedir, file.Name()))

--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -86,6 +86,7 @@ var matchTests = []MatchTest{
   {"broken-symlink", "broken-symlink", true, nil, true},
   {"working-symlink/c/*", "working-symlink/c/d", true, nil, true},
   {"working-sym*/*", "working-symlink/c", true, nil, true},
+  {"b/**/f", "b/symlink-dir/f", true, nil, true},
 }
 
 func TestMatch(t *testing.T) {

--- a/test/b/symlink-dir
+++ b/test/b/symlink-dir
@@ -1,0 +1,1 @@
+../axbxcxdxe/


### PR DESCRIPTION
Hello again - we found another scenario you might be interested in. Test describes it, but basically we resolve literal directories (thanks to your amend to our last PR), but it wasn't yet resolving symlinks matching `**`.

Let me know if there's anything else I can do for this. Thanks!

Separately, I wonder if you've considered using `go fmt` on the code? My editor wanted to do it automatically, but it made for a much larger diff than was necessary so I avoided it. I'd be happy to send a PR for that formatting stuff, if it would be helpful. I find the `go fmt` consistency across projects to be helpful when switching between things.