### PR TITLE
add go.mod to test dir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/bmatcuk/doublestar


### PR DESCRIPTION
an empty go.mod file in the test directory stops go modules from
complaining about the purposely strange file names in the
test fixture directory