### PR TITLE
Use original pattern to check if it is standard

### DIFF
--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -180,7 +180,7 @@ func testPathMatchWith(t *testing.T, idx int, tt MatchTest) {
 		t.Errorf("#%v. Match(%#q, %#q) = %v, %v want %v, %v", idx, pattern, testPath, ok, err, tt.shouldMatch, tt.expectedErr)
 	}
 
-	if isStandardPattern(pattern) {
+	if isStandardPattern(tt.pattern) {
 		stdOk, stdErr := filepath.Match(pattern, testPath)
 		if ok != stdOk || !compareErrors(err, stdErr) {
 			t.Errorf("#%v. PathMatch(%#q, %#q) != filepath.Match(...). Got %v, %v want %v, %v", idx, pattern, testPath, ok, err, stdOk, stdErr)
@@ -226,7 +226,7 @@ func testGlobWith(t *testing.T, idx int, tt MatchTest, basepath string) {
 		t.Errorf("#%v. Glob(%#q) has error %v, but should be %v", idx, pattern, err, tt.expectedErr)
 	}
 
-	if isStandardPattern(pattern) {
+	if isStandardPattern(tt.pattern) {
 		stdMatches, stdErr := filepath.Glob(pattern)
 		if !compareSlices(matches, stdMatches) || !compareErrors(err, stdErr) {
 			t.Errorf("#%v. Glob(%#q) != filepath.Glob(...). Got %#v, %v want %#v, %v", idx, pattern, matches, err, stdMatches, stdErr)


### PR DESCRIPTION
Backslashes from calling filePath.FromSlash on windows were causing the
pattern to be treated as standard when it shouldn't be. This in turn
caused incorrect assertions to be made, failing the tests on windows.