### PR TITLE
Fix abs windows path without volume

### DIFF
--- a/doublestar.go
+++ b/doublestar.go
@@ -336,7 +336,7 @@ func Glob(pattern string) (matches []string, err error) {
 	// volumeName will be an empty string. If it is absolute and we're on a
 	// Windows machine, volumeName will be a drive letter ("C:") for filesystem
 	// paths or \\<server>\<share> for UNC paths.
-	isAbs := filepath.IsAbs(pattern)
+	isAbs := filepath.IsAbs(pattern) || pattern[0] == '\\' || pattern[0] == '/'
 	volumeName := filepath.VolumeName(pattern)
 	isWindowsUNC := strings.HasPrefix(volumeName, `\\`)
 	if isWindowsUNC || isAbs {

--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -180,7 +180,7 @@ func testPathMatchWith(t *testing.T, idx int, tt MatchTest) {
 		t.Errorf("#%v. Match(%#q, %#q) = %v, %v want %v, %v", idx, pattern, testPath, ok, err, tt.shouldMatch, tt.expectedErr)
 	}
 
-	if isStandardPattern(pattern) {
+	if isStandardPattern(tt.pattern) {
 		stdOk, stdErr := filepath.Match(pattern, testPath)
 		if ok != stdOk || !compareErrors(err, stdErr) {
 			t.Errorf("#%v. PathMatch(%#q, %#q) != filepath.Match(...). Got %v, %v want %v, %v", idx, pattern, testPath, ok, err, stdOk, stdErr)
@@ -226,7 +226,7 @@ func testGlobWith(t *testing.T, idx int, tt MatchTest, basepath string) {
 		t.Errorf("#%v. Glob(%#q) has error %v, but should be %v", idx, pattern, err, tt.expectedErr)
 	}
 
-	if isStandardPattern(pattern) {
+	if isStandardPattern(tt.pattern) {
 		stdMatches, stdErr := filepath.Glob(pattern)
 		if !compareSlices(matches, stdMatches) || !compareErrors(err, stdErr) {
 			t.Errorf("#%v. Glob(%#q) != filepath.Glob(...). Got %#v, %v want %#v, %v", idx, pattern, matches, err, stdMatches, stdErr)

--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -201,6 +201,10 @@ func TestGlob(t *testing.T) {
 			// test both relative paths and absolute paths
 			testGlobWith(t, idx, tt, "test")
 			testGlobWith(t, idx, tt, abspath)
+			volumeName := filepath.VolumeName(abspath)
+			if volumeName != "" && !strings.HasPrefix(volumeName, `\\`) {
+				testGlobWith(t, idx, tt, strings.TrimPrefix(abspath, volumeName))
+			}
 		}
 	}
 }


### PR DESCRIPTION
Treat patterns starting with path separators (notably without volume specifiers) on windows as absolute.

This fixes such patterns erroneously being evaluated in the current working dir.

Changes to tests:
- Get windows tests running correctly by fixing standard pattern check in tests
- Additionally test for absolute paths without leading volume specifier