### PR TITLE
Add explicit os and dist definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+os: linux
+  
+dist: "xenial"
+
 go:
   - 1.12
   - 1.13


### PR DESCRIPTION
It is a good practice to define explicitly wich `os` and `dist` the build will be run.

When these info are missing TravisCI uses the default linux `ubuntu:xenial` but in future this behavior can change.