### PR TITLE
Fixes markdown issues and improve titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Path pattern matching and globbing supporting `doublestar` (`**`) patterns.
 
 ![Release](https://img.shields.io/github/release/bmatcuk/doublestar.svg?branch=master)
 [![Build Status](https://travis-ci.org/bmatcuk/doublestar.svg?branch=master)](https://travis-ci.org/bmatcuk/doublestar)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/b5ea01ba45664afd90f36cbc5f346a89)](https://www.codacy.com/manual/edumco/doublestar?utm_source=github.com&utm_medium=referral&utm_content=edumco/doublestar&utm_campaign=Badge_Grade)
 [![codecov.io](https://img.shields.io/codecov/c/github/bmatcuk/doublestar.svg?branch=master)](https://codecov.io/github/bmatcuk/doublestar?branch=master)
 
 ## About

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
+# doublestar
+
+Path pattern matching and globbing supporting `doublestar` (`**`) patterns.
+
 ![Release](https://img.shields.io/github/release/bmatcuk/doublestar.svg?branch=master)
 [![Build Status](https://travis-ci.org/bmatcuk/doublestar.svg?branch=master)](https://travis-ci.org/bmatcuk/doublestar)
 [![codecov.io](https://img.shields.io/codecov/c/github/bmatcuk/doublestar.svg?branch=master)](https://codecov.io/github/bmatcuk/doublestar?branch=master)
 
-# doublestar
+## About
 
 **doublestar** is a [golang](http://golang.org/) implementation of path pattern
-matching and globbing with support for "doublestar" (aka globstar: `**`)
-patterns.
+matching and globbing with support for "doublestar" (aka globstar: `**`) patterns.
 
 doublestar patterns match files and directories recursively. For example, if
 you had the following directory structure:
 
-```
+```bash
 grandparent
 `-- parent
     |-- child1
@@ -43,9 +46,10 @@ To use it in your code, you must import it:
 import "github.com/bmatcuk/doublestar"
 ```
 
-## Functions
+## Usage
 
 ### Match
+
 ```go
 func Match(pattern, name string) (bool, error)
 ```
@@ -59,13 +63,13 @@ such, it always uses `/` as the path separator. If you are writing code that
 will run on systems where `/` is not the path separator (such as Windows), you
 want to use `PathMatch()` (below) instead.
 
-
 ### PathMatch
+
 ```go
 func PathMatch(pattern, name string) (bool, error)
 ```
 
-PathMatch returns true  if `name` matches the file name `pattern`
+PathMatch returns true if `name` matches the file name `pattern`
 ([see below](#patterns)). The difference between Match and PathMatch is that
 PathMatch will automatically use your system's path separator to split `name`
 and `pattern`.
@@ -73,6 +77,7 @@ and `pattern`.
 `PathMatch()` is meant to be a drop-in replacement for `filepath.Match()`.
 
 ### Glob
+
 ```go
 func Glob(pattern string) ([]string, error)
 ```
@@ -83,31 +88,31 @@ directory), or absolute.
 
 `Glob()` is meant to be a drop-in replacement for `filepath.Glob()`.
 
-## Patterns
+### Patterns
 
 **doublestar** supports the following special terms in the patterns:
 
-Special Terms | Meaning
-------------- | -------
-`*`           | matches any sequence of non-path-separators
-`**`          | matches any sequence of characters, including path separators
-`?`           | matches any single non-path-separator character
-`[class]`     | matches any single non-path-separator character against a class of characters ([see below](#character-classes))
-`{alt1,...}`  | matches a sequence of characters if one of the comma-separated alternatives matches
+| Special Terms | Meaning                                                                                                         |
+| ------------- | --------------------------------------------------------------------------------------------------------------- |
+| `*`           | matches any sequence of non-path-separators                                                                     |
+| `**`          | matches any sequence of characters, including path separators                                                   |
+| `?`           | matches any single non-path-separator character                                                                 |
+| `[class]`     | matches any single non-path-separator character against a class of characters ([see below](#character-classes)) |
+| `{alt1,...}`  | matches a sequence of characters if one of the comma-separated alternatives matches                             |
 
 Any character with a special meaning can be escaped with a backslash (`\`).
 
-### Character Classes
+#### Character Classes
 
 Character classes support the following:
 
-Class      | Meaning
----------- | -------
-`[abc]`    | matches any single character within the set
-`[a-z]`    | matches any single character in the range
-`[^class]` | matches any single character which does *not* match the class
+| Class      | Meaning                                                       |
+| ---------- | ------------------------------------------------------------- |
+| `[abc]`    | matches any single character within the set                   |
+| `[a-z]`    | matches any single character in the range                     |
+| `[^class]` | matches any single character which does _not_ match the class |
 
-## Abstracting the `os` package
+### Abstracting the `os` package
 
 **doublestar** by default uses the `Open`, `Stat`, and `Lstat`, functions and
 `PathSeparator` value from the standard library's `os` package. To abstract
@@ -118,12 +123,16 @@ operate on an `OS` interface:
 
 ```go
 type OS interface {
-	Lstat(name string) (os.FileInfo, error)
-	Open(name string) (*os.File, error)
-	PathSeparator() rune
-	Stat(name string) (os.FileInfo, error)
+    Lstat(name string) (os.FileInfo, error)
+    Open(name string) (*os.File, error)
+    PathSeparator() rune
+    Stat(name string) (os.FileInfo, error)
 }
 ```
 
 `StandardOS` is a value that implements this interface by calling functions in
 the standard library's `os` package.
+
+## License
+
+[MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Path pattern matching and globbing supporting `doublestar` (`**`) patterns.
 
 ![Release](https://img.shields.io/github/release/bmatcuk/doublestar.svg?branch=master)
 [![Build Status](https://travis-ci.org/bmatcuk/doublestar.svg?branch=master)](https://travis-ci.org/bmatcuk/doublestar)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/b5ea01ba45664afd90f36cbc5f346a89)](https://www.codacy.com/manual/edumco/doublestar?utm_source=github.com&utm_medium=referral&utm_content=edumco/doublestar&utm_campaign=Badge_Grade)
 [![codecov.io](https://img.shields.io/codecov/c/github/bmatcuk/doublestar.svg?branch=master)](https://codecov.io/github/bmatcuk/doublestar?branch=master)
 
 ## About


### PR DESCRIPTION
This pull request fixes several Markdown rules to put the markdown under Github recommendations.
- Puts the title in the first line
- Adds a subtitle
- Adds a continue code quality analysis badge
- Fixes spacing (add/remove spaces, tabs and lines)
- Adds language description to all code fences
- Adds an About section title
- Adds an License Section linking the LICENSE file

