### PR TITLE
add GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+on:
+  pull_request:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.15.x
+    - name: Cache Go modules
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build
+      run: go build ./...
+    - name: Test
+      run: go test ./...
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Lint
+      uses: golangci/golangci-lint-action@v1
+      with:
+        version: v1.31


### PR DESCRIPTION
Eventually, this could replace Travis. It includes a build and test check, and invokes `golangci-lint` with its default configuration.