### PR TITLE
Added support for Linux on power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ go:
 os:
   - linux
   - windows
-
+arch:
+  - amd64
+  - ppc64le
 before_install:
   - go get -t -v ./...
 


### PR DESCRIPTION

Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/ujjwalsh/doublestar/builds/188448501
Please have a look.

Regards,
ujjwal