### PR TITLE
Fewer dirs open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ _testmain.go
 
 # test directory
 test/
+
+# test output
+coverage.txt
+
+# GoLand files
+.idea

--- a/doublestar.go
+++ b/doublestar.go
@@ -423,6 +423,7 @@ func doGlob(vos OS, basedir, pattern string, matches []string) (m []string, e er
 	}
 
 	// otherwise, we need to check each item in the directory...
+
 	// first, if basedir is a symlink, follow it...
 	if (fi.Mode() & os.ModeSymlink) != 0 {
 		fi, err = vos.Stat(basedir)
@@ -436,21 +437,11 @@ func doGlob(vos OS, basedir, pattern string, matches []string) (m []string, e er
 		return
 	}
 
-	// read directory
-	dir, err := vos.Open(basedir)
+	files, err := filesInDir(vos, basedir)
 	if err != nil {
 		return
 	}
-	defer func() {
-		if err := dir.Close(); e == nil {
-			e = err
-		}
-	}()
 
-	files, err := dir.Readdir(-1)
-	if err != nil {
-		return
-	}
 	sort.Slice(files, func(i, j int) bool { return files[i].Name() < files[j].Name() })
 
 	slashIdx := indexRuneWithEscaping(pattern, '/')
@@ -504,6 +495,25 @@ func doGlob(vos OS, basedir, pattern string, matches []string) (m []string, e er
 			}
 		}
 	}
+	return
+}
+
+func filesInDir(vos OS, dirPath string) (files []os.FileInfo, e error) {
+	dir, err := vos.Open(dirPath)
+	if err != nil {
+		return nil, nil
+	}
+	defer func() {
+		if err := dir.Close(); e == nil {
+			e = err
+		}
+	}()
+
+	files, err = dir.Readdir(-1)
+	if err != nil {
+		return nil, nil
+	}
+
 	return
 }
 

--- a/examples/find.go
+++ b/examples/find.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v2"
+)
+
+// To run:
+// $ go run find.go <glob-pattern>
+
+// For example:
+// $ go run find.go '/usr/bin/*' 			# Make sure to escape as necessary for your shell
+
+func main() {
+	pattern := os.Args[1]
+	fmt.Printf("Searching on disk for pattern: %s\n\n", pattern)
+
+	matches, err := doublestar.Glob(pattern)
+	if err != nil {
+		fmt.Printf("Error: %v", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf(strings.Join(matches, "\n"))
+	fmt.Print("\n\n")
+	fmt.Printf("Found %d items.\n", len(matches))
+}


### PR DESCRIPTION
Hello! This PR does the following:

1. It introduces a minimal amount of benchmarking. I came across issue #19 after noticing some slowness in the implementation (for how we're using it specifically). There's certainly more that can be done with benckmarks, but I see from reading the issue that performance isn't a key criterion for doublestar — so feel free to discard this part!
1. It introduces an executable entrypoint for the `Glob` function, just so that it's easy to examine behavior of the function quickly from the shell, without needing to incorporate the function into a larger project. For example, you can run `go run ./examples/find.go '/Users/dan/**/*.go'`.
1. It addresses an issue where, as directories were being traversed, directories remain open even after the contained files had been read. Every opened directory was ultimately closed, but because the call to `dir.Close()` was deferred, and the function body was large enough that recursive operations were being performed within the same function, directories ended up remaining open longer than necessary.