### PR TITLE
Return error when trying to open directory

### DIFF
--- a/doublestar.go
+++ b/doublestar.go
@@ -378,7 +378,7 @@ func doGlob(vos OS, basedir, pattern string, matches []string) (m []string, e er
 
 	files, err := filesInDir(vos, basedir)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	sort.Slice(files, func(i, j int) bool { return files[i].Name() < files[j].Name() })
@@ -440,7 +440,7 @@ func doGlob(vos OS, basedir, pattern string, matches []string) (m []string, e er
 func filesInDir(vos OS, dirPath string) (files []os.FileInfo, e error) {
 	dir, err := vos.Open(dirPath)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	defer func() {
 		if err := dir.Close(); e == nil {


### PR DESCRIPTION
At the moment if there is an error opening a directory it results in a silent failure, in order to gracefully handle such cases I require an error to be returned. This PR updates the `filesInDir` function to return the error.

There isn't a clear path yet to upgrade to v4 in the project I need this change for, so I am not sure if this has been resolved in the new version. Hopefully it is ok to create a pr against v3 in the meantime to address this issue. If you are curious, this is the issue this pr will help address: https://github.com/influxdata/telegraf/issues/9129