### PR TITLE
Support patterns with escaped wildcard characters

### DIFF
--- a/glob.go
+++ b/glob.go
@@ -311,7 +311,7 @@ func indexMatchedOpeningAlt(s string) int {
 
 // Returns true if the path exists
 func exists(fsys fs.FS, name string) bool {
-	if _, err := fs.Stat(fsys, name); os.IsNotExist(err) {
+	if _, err := fs.Stat(fsys, name); err != nil {
 		return false
 	}
 	return true

--- a/globwalk.go
+++ b/globwalk.go
@@ -44,9 +44,11 @@ func doGlobWalk(fsys fs.FS, pattern string, firstSegment bool, fn GlobWalkFunc) 
 	if patternStart == -1 {
 		// pattern doesn't contain any meta characters - does a file matching the
 		// pattern exist?
-		info, err := fs.Stat(fsys, pattern)
+		// The pattern may contain escaped wildcard characters for an exact path match.
+		path := unescapeWildcards(pattern)
+		info, err := fs.Stat(fsys, path)
 		if err == nil {
-			err = fn(pattern, dirEntryFromFileInfo(info))
+			err = fn(path, dirEntryFromFileInfo(info))
 			return err
 		} else {
 			// ignore IO errors


### PR DESCRIPTION
Based on the `filepath.Glob` and `fs.Glob` behavior, I think I would expect `doublestar.Glob()` to handle file names that have wildcard characters (`*` and `?`).

Here is a short program that illustrates glob expansion using `filepath.Glob` and `fs.Glob`:
https://go.dev/play/p/lo_VclFQCj6

One of the unit test in this PR fails. Unless I am mistaken, I think the UT should succeed. If there is a file named `*`, shouldn't `doublestar.Glob(fs, "\\*")` return `[]string{"*"}`?

1. Run `gofmt`.
2. Add unit tests to show problem with patterns containing escaped wildcard characters `\\*` and `\\?.
3. Fix `exists` when pattern contains escaped wildcard characters `\\*` and `\\?`.
4. On Windows, escaping is disabled. Instead, '\\' is treated as path separator.