### PR TITLE
support broken symlinks if underlying FS supports Lstat

### DIFF
--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -135,8 +135,7 @@ var matchTests = []MatchTest{
 	{"**/*.txt", "abc/【test】.txt", true, nil, false, true, 1, 1},
 	{"**/【*", "abc/【test】.txt", true, nil, false, true, 1, 1},
 	{"**/{a,b}", "a/b", true, nil, false, true, 5, 5},
-	// unfortunately, io/fs can't handle this, so neither can Glob =(
-	{"broken-symlink", "broken-symlink", true, nil, true, false, 1, 1},
+	{"broken-sym*", "broken-symlink", true, nil, true, !onWindows, 1, 0},
 	{"working-symlink/c/*", "working-symlink/c/d", true, nil, true, !onWindows, 1, 1},
 	{"working-sym*/*", "working-symlink/c", true, nil, true, !onWindows, 1, 1},
 	{"b/**/f", "b/symlink-dir/f", true, nil, false, !onWindows, 2, 2},

--- a/globwalk.go
+++ b/globwalk.go
@@ -57,7 +57,7 @@ func doGlobWalk(fsys fs.FS, pattern string, firstSegment bool, fn GlobWalkFunc) 
 		// pattern exist?
 		// The pattern may contain escaped wildcard characters for an exact path match.
 		path := unescapeMeta(pattern)
-		info, err := fs.Stat(fsys, path)
+		info, err := lstat(fsys, path)
 		if err == nil {
 			err = fn(path, dirEntryFromFileInfo(info))
 			if err == SkipDir {
@@ -220,7 +220,7 @@ func globDirWalk(fsys fs.FS, dir, pattern string, canMatchFiles bool, fn GlobWal
 		// pattern can be an empty string if the original pattern ended in a slash,
 		// in which case, we should just return dir, but only if it actually exists
 		// and it's a directory (or a symlink to a directory)
-		info, err := fs.Stat(fsys, dir)
+		info, err := lstat(fsys, dir)
 		if err != nil || !info.IsDir() {
 			return nil
 		}
@@ -234,7 +234,7 @@ func globDirWalk(fsys fs.FS, dir, pattern string, canMatchFiles bool, fn GlobWal
 
 	if pattern == "**" {
 		// `**` can match *this* dir
-		info, err := fs.Stat(fsys, dir)
+		info, err := lstat(fsys, dir)
 		if err != nil || !info.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
This PR patches doublestar to support broken symlinks.

Although [the `io/fs.StatFS` interface](https://pkg.go.dev/io/fs#StatFS) does not include an `Lstat` method, we can test whether the type implementing the interface has a `Lstat` method and use it if available.

This is needed to fix https://github.com/twpayne/chezmoi/issues/2016.