### PR TITLE
add option to fail on I/O errors

### DIFF
--- a/globopts.go
+++ b/globopts.go
@@ -1,0 +1,43 @@
+package doublestar
+
+// glob is an internal type to store options during globbing.
+type glob struct {
+	failOnIOErrors bool
+}
+
+// Opt represents a setting that can be passed to GlobWalk and Glob.
+type Opt func(*glob)
+
+func newGlob(opts ...Opt) *glob {
+	g := glob{}
+	g.applyOpts(opts)
+	return &g
+}
+
+func (g *glob) applyOpts(opts []Opt) {
+	for _, o := range opts {
+		o(g)
+	}
+}
+
+// WithFailOnIOErrors is an option that can be passed to Glob, GlobWalk and
+// FilepathGlob. If passed, it enables aborting and returning the error when an
+// I/O error is encountered.
+// When this option is not passed, I/O errors cause that files or directories
+// are skipped and globbing continues.
+func WithFailOnIOErrors() Opt {
+	return func(g *glob) {
+		g.failOnIOErrors = true
+	}
+}
+
+// forwardErrIfFailOnIOErrors is used to wrap the return values of I/O
+// functions.
+// When WithFailOnIOErrors enabled, it return err, otherwise it always returns
+// nil.
+func (g *glob) forwardErrIfFailOnIOErrors(err error) error {
+	if g.failOnIOErrors {
+		return err
+	}
+	return nil
+}

--- a/utils.go
+++ b/utils.go
@@ -13,16 +13,16 @@ import (
 // The second string is everything after that slash. For example, given the
 // pattern:
 //
-//   ../../path/to/meta*/**
-//                ^----------- split here
+//	../../path/to/meta*/**
+//	             ^----------- split here
 //
 // SplitPattern returns "../../path/to" and "meta*/**". This is useful for
 // initializing os.DirFS() to call Glob() because Glob() will silently fail if
 // your pattern includes `/./` or `/../`. For example:
 //
-//   base, pattern := SplitPattern("../../path/to/meta*/**")
-//   fsys := os.DirFS(base)
-//   matches, err := Glob(fsys, pattern)
+//	base, pattern := SplitPattern("../../path/to/meta*/**")
+//	fsys := os.DirFS(base)
+//	matches, err := Glob(fsys, pattern)
 //
 // If SplitPattern cannot find somewhere to split the pattern (for example,
 // `meta*/**`), it will return "." and the unaltered pattern (`meta*/**` in
@@ -31,7 +31,6 @@ import (
 // Of course, it is your responsibility to decide if the returned base path is
 // "safe" in the context of your application. Perhaps you could use Match() to
 // validate against a list of approved base directories?
-//
 func SplitPattern(p string) (base, pattern string) {
 	base = "."
 	pattern = p
@@ -62,29 +61,30 @@ func SplitPattern(p string) (base, pattern string) {
 // pattern may describe hierarchical names such as usr/*/bin/ed.
 //
 // FilepathGlob ignores file system errors such as I/O errors reading
-// directories.  The only possible returned error is ErrBadPattern, reporting
-// that the pattern is malformed.
+// directories by default. The only possible returned error is ErrBadPattern,
+// reporting that the pattern is malformed.
+// To enable aborting on I/O errors, the WithFailOnIOErrors option can be
+// passed.
 //
 // Note: FilepathGlob is a convenience function that is meant as a drop-in
 // replacement for `path/filepath.Glob()` for users who don't need the
 // complication of io/fs. Basically, it:
-//   * Runs `filepath.Clean()` and `ToSlash()` on the pattern
-//   * Runs `SplitPattern()` to get a base path and a pattern to Glob
-//   * Creates an FS object from the base path and `Glob()s` on the pattern
-//   * Joins the base path with all of the matches from `Glob()`
+//   - Runs `filepath.Clean()` and `ToSlash()` on the pattern
+//   - Runs `SplitPattern()` to get a base path and a pattern to Glob
+//   - Creates an FS object from the base path and `Glob()s` on the pattern
+//   - Joins the base path with all of the matches from `Glob()`
 //
 // Returned paths will use the system's path separator, just like
 // `filepath.Glob()`.
 //
 // Note: the returned error doublestar.ErrBadPattern is not equal to
 // filepath.ErrBadPattern.
-//
-func FilepathGlob(pattern string) (matches []string, err error) {
+func FilepathGlob(pattern string, opts ...Opt) (matches []string, err error) {
 	pattern = filepath.Clean(pattern)
 	pattern = filepath.ToSlash(pattern)
 	base, f := SplitPattern(pattern)
 	fs := os.DirFS(base)
-	if matches, err = Glob(fs, f); err != nil {
+	if matches, err = Glob(fs, f, opts...); err != nil {
 		return nil, err
 	}
 	for i := range matches {


### PR DESCRIPTION
This commit introduces an Option for Glob(), GlobWalk() and FilepathGlob() to handle encountered I/O errors as fatal. When the option is enabled and an I/O error happens, globbing is aborted and the error is returned.
By default the globbing function continue when an I/O error happens and only skip the related file an directory. This is the same behaviour as before.

The new option is useful when the user should be notified about broken symlinks, non-existing paths in the pattern or general I/O errors that were encountered.

An Opt type is introduced that follows the Option pattern. Opt is returned by the WithFailOnIOErrors() function. The exported functions are changed to accept as last argument a variadic ...Opt argument.
When the functions are called, they instantiate a glob type instance, that stores the value of the option in an failOnIOErrors field. All functions that do I/O operations are converted to being methods of glob, to be able to access failOnIOErrors.
If an I/O operation encounters an error and failOnIOErrors is set, the error is returned.
If failOnIOErrors is not set, the functions behave the same as before.

The introduced Opt type and glob struct allow to extend the package with further options, without having to break the API in the future.

Testcases were added for Glob and GlobWalk to check if WithFailOnIOErrors causes these functions to abort and return an error.

The code could be refactored in a follow-up to use the new glob type to store the arguments that are currently passed around on functions calls like fsys and pattern.

------------

Please let me know if you are interested in general to add this functionality and if there is something to improve.

I plan to replace the existing doublestar implementation in https://github.com/simplesurance/baur with yours and require for that the functionality of this PR.
