### PR TITLE
added WithFailOnPatternNotExist

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ that if the glob pattern references a path that does not exist (such as
 `nonexistent/path/*`), this is _not_ considered an IO error: it is considered a
 pattern with no matches.
 
+```go
+WithFailOnPatternNotExist()
+```
+
+If passed, doublestar will abort and return `doublestar.ErrPatternNotExist` if
+the pattern references a path that does not exist before any meta characters
+such as `nonexistent/path/*`. Note that alts (ie, `{...}`) are expanded before
+this check. In other words, a pattern such as `{a,b}/*` may fail if either `a`
+or `b` do not exist but `*/{a,b}` will never fail because the star may match
+nothing.
+
 ### Glob
 
 ```go

--- a/doublestar.go
+++ b/doublestar.go
@@ -1,8 +1,13 @@
 package doublestar
 
 import (
+	"errors"
 	"path"
 )
 
 // ErrBadPattern indicates a pattern was malformed.
 var ErrBadPattern = path.ErrBadPattern
+
+// ErrPatternNotExist indicates that the pattern passed to Glob, GlobWalk, or
+// FilepathGlob references a path that does not exist.
+var ErrPatternNotExist = errors.New("pattern does not exist")

--- a/globoptions.go
+++ b/globoptions.go
@@ -2,7 +2,8 @@ package doublestar
 
 // glob is an internal type to store options during globbing.
 type glob struct {
-	failOnIOErrors bool
+	failOnIOErrors        bool
+	failOnPatternNotExist bool
 }
 
 // GlobOption represents a setting that can be passed to Glob, GlobWalk, and
@@ -30,9 +31,24 @@ func WithFailOnIOErrors() GlobOption {
 	}
 }
 
+// WithFailOnPatternNotExist is an option that can be passed to Glob, GlobWalk,
+// or FilepathGlob. If passed, doublestar will abort and return
+// ErrPatternNotExist if the pattern references a path that does not exist
+// before any meta charcters such as `nonexistent/path/*`. Note that alts (ie,
+// `{...}`) are expanded before this check. In other words, a pattern such as
+// `{a,b}/*` may fail if either `a` or `b` do not exist but `*/{a,b}` will
+// never fail because the star may match nothing.
+//
+func WithFailOnPatternNotExist() GlobOption {
+	return func(g *glob) {
+		g.failOnPatternNotExist = true
+	}
+}
+
 // forwardErrIfFailOnIOErrors is used to wrap the return values of I/O
 // functions. When failOnIOErrors is enabled, it will return err; otherwise, it
 // always returns nil.
+//
 func (g *glob) forwardErrIfFailOnIOErrors(err error) error {
 	if g.failOnIOErrors {
 		return err
@@ -40,9 +56,26 @@ func (g *glob) forwardErrIfFailOnIOErrors(err error) error {
 	return nil
 }
 
+// handleErrNotExist handles fs.ErrNotExist errors. If
+// WithFailOnPatternNotExist has been enabled and canFail is true, this will
+// return ErrPatternNotExist. Otherwise, it will return nil.
+//
+func (g *glob) handlePatternNotExist(canFail bool) error {
+	if canFail && g.failOnPatternNotExist {
+		return ErrPatternNotExist
+	}
+	return nil
+}
+
+// Format options for debugging/testing purposes
 func (g *glob) GoString() string {
 	if g.failOnIOErrors {
+		if g.failOnPatternNotExist {
+			return "opts: WithFailOnIOErrors, WithFailOnPatternNotExist"
+		}
 		return "opts: WithFailOnIOErrors"
+	} else if g.failOnPatternNotExist {
+		return "opts: WithFailOnPatternNotExist"
 	}
 	return "opts: nil"
 }

--- a/utils.go
+++ b/utils.go
@@ -100,7 +100,7 @@ func FilepathGlob(pattern string, opts ...GlobOption) (matches []string, err err
 		if _, err = os.Lstat(pattern); err != nil {
 			g := newGlob(opts...)
 			if errors.Is(err, os.ErrNotExist) {
-				return nil, nil
+				return nil, g.handlePatternNotExist(true)
 			}
 			return nil, g.forwardErrIfFailOnIOErrors(err)
 		}


### PR DESCRIPTION
Added an option to fail if the glob pattern matches a path that does not exist: `WithFailOnPatternNotExist`.

If passed, doublestar will abort and return `doublestar.ErrPatternNotExist` if the pattern references a path that does not exist before any meta characters such as `nonexistent/path/*`. Note that alts (ie, `{...}`) are expanded before this check. In other words, a pattern such as `{a,b}/*` may fail if either `a` or `b` do not exist but `*/{a,b}` will never fail because the star may match nothing.

I decided to return a new error instead of `fs.ErrNotExist` to differentiate between this unique case vs some other case that may result in an actual IO error (if both this option and `WithFailOnIOErrors` is enabled).