### PR TITLE
fixes #68 corner cases for FilepathGlob

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
+    patch:
+      default:
+        target: 70%

--- a/utils.go
+++ b/utils.go
@@ -86,6 +86,11 @@ func FilepathGlob(pattern string, opts ...GlobOption) (matches []string, err err
 	pattern = filepath.Clean(pattern)
 	pattern = filepath.ToSlash(pattern)
 	base, f := SplitPattern(pattern)
+	if f == "" || f == "." || f == ".." {
+		// some special cases to match filepath.Glob behavior
+		return []string{pattern}, nil
+	}
+
 	fs := os.DirFS(base)
 	if matches, err = Glob(fs, f, opts...); err != nil {
 		return nil, err

--- a/utils.go
+++ b/utils.go
@@ -84,10 +84,10 @@ func SplitPattern(p string) (base, pattern string) {
 // filepath.ErrBadPattern.
 //
 func FilepathGlob(pattern string, opts ...GlobOption) (matches []string, err error) {
-	cleaned := filepath.Clean(pattern)
-	cleaned = filepath.ToSlash(cleaned)
-	base, f := SplitPattern(cleaned)
-	if indexMeta(f) == -1 {
+	pattern = filepath.Clean(pattern)
+	pattern = filepath.ToSlash(pattern)
+	base, f := SplitPattern(pattern)
+	if f == "" || f == "." || f == ".." {
 		// some special cases to match filepath.Glob behavior
 		if !ValidatePathPattern(pattern) {
 			return nil, ErrBadPattern
@@ -104,7 +104,7 @@ func FilepathGlob(pattern string, opts ...GlobOption) (matches []string, err err
 			}
 			return nil, g.forwardErrIfFailOnIOErrors(err)
 		}
-		return []string{pattern}, nil
+		return []string{filepath.FromSlash(pattern)}, nil
 	}
 
 	fs := os.DirFS(base)

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,44 @@
+package doublestar
+
+import (
+	"testing"
+)
+
+type FilepathGlobTest struct {
+	pattern, result string
+}
+
+var filepathGlobTests = []FilepathGlobTest{
+	{".", "."},
+	{"././.", "."},
+	{"..", ".."},
+	{"../.", ".."},
+	{".././././", ".."},
+	{"../..", "../.."},
+	{"/", "/"},
+	{"./", "."},
+	{"/.", "/"},
+	{"/././././", "/"},
+}
+
+func TestSpecialFilepathGlobCases(t *testing.T) {
+	for idx, tt := range filepathGlobTests {
+		testSpecialFilepathGlobCasesWith(t, idx, tt)
+	}
+}
+
+func testSpecialFilepathGlobCasesWith(t *testing.T, idx int, tt FilepathGlobTest) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("#%v. FilepathGlob(%#q) panicked with: %#v", idx, tt.pattern, r)
+		}
+	}()
+
+	matches, err := FilepathGlob(tt.pattern)
+	if err != nil {
+		t.Errorf("#%v. FilepathGlob(%#q) has error %v", idx, tt.pattern, err)
+	}
+	if len(matches) != 1 || matches[0] != tt.result {
+		t.Errorf("#%v. FilepathGlob(%#q) = %#v - should be []string{%#v}", idx, tt.pattern, matches, tt.result)
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -44,6 +44,9 @@ func testSpecialFilepathGlobCasesWith(t *testing.T, idx int, pattern string) {
 	if len(results) != 1 {
 		t.Errorf("#%v. filepath.Glob(%#q) should have 1 result but has %v", idx, pattern, len(results))
 	}
+
+	// doublestar.FilepathGlob Cleans the path
+	results[0] = filepath.Clean(results[0])
 	if matches[0] != results[0] {
 		t.Errorf("#%v. FilepathGlob(%#q) = %#v - should be %#v", idx, pattern, matches, results)
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -16,6 +16,7 @@ var filepathGlobTests = []string{
 	"./",
 	"/.",
 	"/././././",
+	"nopermission/.",
 }
 
 func TestSpecialFilepathGlobCases(t *testing.T) {
@@ -33,21 +34,13 @@ func testSpecialFilepathGlobCasesWith(t *testing.T, idx int, pattern string) {
 
 	pattern = filepath.FromSlash(pattern)
 	matches, err := FilepathGlob(pattern)
-	if err != nil {
-		t.Errorf("#%v. FilepathGlob(%#q) has error %v", idx, pattern, err)
-	}
-	if len(matches) != 1 {
-		t.Errorf("#%v. FilepathGlob(%#q) should have 1 result but has %v", idx, pattern, len(matches))
-	}
-
-	results, err := filepath.Glob(pattern)
-	if len(results) != 1 {
-		t.Errorf("#%v. filepath.Glob(%#q) should have 1 result but has %v", idx, pattern, len(results))
-	}
+	results, stdErr := filepath.Glob(pattern)
 
 	// doublestar.FilepathGlob Cleans the path
-	results[0] = filepath.Clean(results[0])
-	if matches[0] != results[0] {
-		t.Errorf("#%v. FilepathGlob(%#q) = %#v - should be %#v", idx, pattern, matches, results)
+	for idx, result := range results {
+		results[idx] = filepath.Clean(result)
+	}
+	if !compareSlices(matches, results) || !compareErrors(err, stdErr) {
+		t.Errorf("#%v. FilepathGlob(%#q) != filepath.Glob(%#q). Got %#v, %v want %#v, %v", idx, pattern, pattern, matches, err, results, stdErr)
 	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,43 +2,49 @@ package doublestar
 
 import (
 	"testing"
+	"path/filepath"
 )
 
-type FilepathGlobTest struct {
-	pattern, result string
-}
-
-var filepathGlobTests = []FilepathGlobTest{
-	{".", "."},
-	{"././.", "."},
-	{"..", ".."},
-	{"../.", ".."},
-	{".././././", ".."},
-	{"../..", "../.."},
-	{"/", "/"},
-	{"./", "."},
-	{"/.", "/"},
-	{"/././././", "/"},
+var filepathGlobTests = []string{
+	".",
+	"././.",
+	"..",
+	"../.",
+	".././././",
+	"../..",
+	"/",
+	"./",
+	"/.",
+	"/././././",
 }
 
 func TestSpecialFilepathGlobCases(t *testing.T) {
-	for idx, tt := range filepathGlobTests {
-		testSpecialFilepathGlobCasesWith(t, idx, tt)
+	for idx, pattern := range filepathGlobTests {
+		testSpecialFilepathGlobCasesWith(t, idx, pattern)
 	}
 }
 
-func testSpecialFilepathGlobCasesWith(t *testing.T, idx int, tt FilepathGlobTest) {
+func testSpecialFilepathGlobCasesWith(t *testing.T, idx int, pattern string) {
 	defer func() {
 		if r := recover(); r != nil {
-			t.Errorf("#%v. FilepathGlob(%#q) panicked with: %#v", idx, tt.pattern, r)
+			t.Errorf("#%v. FilepathGlob(%#q) panicked with: %#v", idx, pattern, r)
 		}
 	}()
 
-	matches, err := FilepathGlob(tt.pattern)
+	pattern = filepath.FromSlash(pattern)
+	matches, err := FilepathGlob(pattern)
 	if err != nil {
-		t.Errorf("#%v. FilepathGlob(%#q) has error %v", idx, tt.pattern, err)
+		t.Errorf("#%v. FilepathGlob(%#q) has error %v", idx, pattern, err)
 	}
-	if len(matches) != 1 || matches[0] != tt.result {
-		t.Errorf("#%v. FilepathGlob(%#q) = %#v - should be []string{%#v}", idx, tt.pattern, matches, tt.result)
+	if len(matches) != 1 {
+		t.Errorf("#%v. FilepathGlob(%#q) should have 1 result but has %v", idx, pattern, len(matches))
+	}
+
+	results, err := filepath.Glob(pattern)
+	if len(results) != 1 {
+		t.Errorf("#%v. filepath.Glob(%#q) should have 1 result but has %v", idx, pattern, len(results))
+	}
+	if matches[0] != results[0] {
+		t.Errorf("#%v. FilepathGlob(%#q) = %#v - should be %#v", idx, pattern, matches, results)
 	}
 }


### PR DESCRIPTION
Handles some corner-case differences between `filepath.Glob` and `doublestar.FilepathGlob`.