### PR TITLE
Add ability to compile a pattern

### DIFF
--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -257,6 +257,13 @@ func testCompileWith(t *testing.T, idx int, tt MatchTest) {
 	if ok != tt.shouldMatch || err != tt.expectedErr {
 		t.Errorf("#%v. Match(%#q, %#q) = %v, %v want %v, %v", idx, tt.pattern, tt.testPath, ok, err, tt.shouldMatch, tt.expectedErr)
 	}
+
+	if tt.isStandard {
+		stdOk, stdErr := path.Match(tt.pattern, tt.testPath)
+		if ok != stdOk || !compareErrors(err, stdErr) {
+			t.Errorf("#%v. Match(%#q, %#q) != path.Match(...). Got %v, %v want %v, %v", idx, tt.pattern, tt.testPath, ok, err, stdOk, stdErr)
+		}
+	}
 }
 
 func testMatchWith(t *testing.T, idx int, tt MatchTest) {

--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -236,6 +236,29 @@ func TestMatch(t *testing.T) {
 	}
 }
 
+func TestCompile(t *testing.T) {
+	for idx, tt := range matchTests {
+		testCompileWith(t, idx, tt)
+	}
+}
+
+func testCompileWith(t *testing.T, idx int, tt MatchTest) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("#%v. Match(%#q, %#q) panicked: %#v", idx, tt.pattern, tt.testPath, r)
+		}
+	}()
+
+	ok := false
+	pat, err := Compile(tt.pattern)
+	if err == nil {
+		ok = pat.Match(tt.testPath)
+	}
+	if ok != tt.shouldMatch || err != tt.expectedErr {
+		t.Errorf("#%v. Match(%#q, %#q) = %v, %v want %v, %v", idx, tt.pattern, tt.testPath, ok, err, tt.shouldMatch, tt.expectedErr)
+	}
+}
+
 func testMatchWith(t *testing.T, idx int, tt MatchTest) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/match.go
+++ b/match.go
@@ -119,14 +119,7 @@ func MustCompile(pattern string) *Pattern {
 
 // Match reports whether the name matches this pattern
 func (p *Pattern) Match(name string) bool {
-	matches, err := Match(p.pattern, name)
-	// This shouldn't be able to happen, since we validated the pattern already
-	// When this function is converted to actually doing a match instead of calling Match()
-	// on the initial pattern, this can go away
-	if err != nil {
-		panic(err)
-	}
-	return matches
+	return MatchUnvalidated(p.pattern, name)
 }
 
 func matchWithSeparator(pattern, name string, separator rune, validate bool) (matched bool, err error) {

--- a/match.go
+++ b/match.go
@@ -89,6 +89,46 @@ func PathMatchUnvalidated(pattern, name string) bool {
 	return matched
 }
 
+// Pattern is a representation of a compiled glob pattern.
+type Pattern struct {
+	// initial implementation doesn't actually "compile", just saves the pattern to use when matching
+	// Obviously long term we'll want to store some kind of tree or something
+	pattern string
+}
+
+// Compile parses a pattern and returns, if successful, a [Pattern] object
+// that can be used to match against text.
+func Compile(pattern string) (*Pattern, error) {
+	if !ValidatePattern(pattern) {
+		return nil, ErrBadPattern
+	}
+	return &Pattern{
+		pattern: pattern,
+	}, nil
+}
+
+// MustCompile is like Compile but panics if the expression cannot be parsed.
+func MustCompile(pattern string) *Pattern {
+
+	p, err := Compile(pattern)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+// Match reports whether the name matches this pattern
+func (p *Pattern) Match(name string) bool {
+	matches, err := Match(p.pattern, name)
+	// This shouldn't be able to happen, since we validated the pattern already
+	// When this function is converted to actually doing a match instead of calling Match()
+	// on the initial pattern, this can go away
+	if err != nil {
+		panic(err)
+	}
+	return matches
+}
+
 func matchWithSeparator(pattern, name string, separator rune, validate bool) (matched bool, err error) {
 	return doMatchWithSeparator(pattern, name, separator, validate, -1, -1, -1, -1, 0, 0)
 }


### PR DESCRIPTION
## What

Add ability to compile a `Pattern` once and use it for subsequent matches.

*Note* this is currently a naive implementation that just calls the existing `Match()`, I wanted to firstly gauge interest of the maintainers to see if this is a feature worth implementing, and also to discuss what the various exported identifiers should be.

## Why

`ValidatePattern()`, allows the user to inspect whether there is an error before saving the pattern for later. This goes a step further, and removes the `error` from the analogous `Match()` function, since it cannot fail once compiled, making it a bit cleaner to use.

Additionally, presumably a compiled pattern could be made to be more efficient, though I haven't dug into the implementation there yet. My naive implementation is only very slightly better than Match(), since it makes use of the existing MatchUnvalidated, which skips some validation and therefore saves time.

I modeled the methods and signatures after regexp in go's standard library (quoted in part here):
```
func MatchString(pattern string, s string) (matched bool, err error)
type Regexp struct{ ... }
    func Compile(expr string) (*Regexp, error)
    func MustCompile(str string) *Regexp
    func (re *Regexp) Match(s string) bool
```
https://pkg.go.dev/regexp
## Usage

```
    pattern, err := doublestar.Compile("foo/*")
    if err != nil {
        log.Fatal(err)
    }
    if pattern.Match("foo/bar") {
        fmt.Println("Pattern matches foo/bar")
    }
    if pattern.Match("bar/foo") {
        fmt.Println("Pattern matches bar/foo")
    }
    
    // Prints "Pattern matches foo/bar"
```

## Testing

The compiled version is run through the same suite of tests as the normal version, which also serves to make sure they are in lock-step.

## References

Closes: #85