### PR TITLE
Skip more validation

### DIFF
--- a/doublestar_test.go
+++ b/doublestar_test.go
@@ -281,8 +281,8 @@ func TestMatchUnvalidated(t *testing.T) {
 	for idx, tt := range matchTests {
 		testMatchUnvalidatedWith(t, idx, tt)
 	}
-	// Not only test that they get the right matches, but make sure Unvalidated is properly *skipping* validation
 
+	// Not only test that they get the right matches, but make sure Unvalidated is properly *skipping* validation
 	unvalidatedTests := []struct {
 		pattern, testPath      string // a pattern and path to test the pattern on
 		expectedErrValidated   error  // the error expected if the pattern was being validated

--- a/match.go
+++ b/match.go
@@ -319,10 +319,10 @@ MATCH:
 	// we've reached the end of `name`; we've successfully matched if we've also
 	// reached the end of `pattern`, or if the rest of `pattern` can match a
 	// zero-length string
-	return isZeroLengthPattern(pattern[patIdx:], separator)
+	return isZeroLengthPattern(pattern[patIdx:], separator, validate)
 }
 
-func isZeroLengthPattern(pattern string, separator rune) (ret bool, err error) {
+func isZeroLengthPattern(pattern string, separator rune, validate bool) (ret bool, err error) {
 	// `/**`, `**/`, and `/**/` are special cases - a pattern such as `path/to/a/**` or `path/to/a/**/`
 	// *should* match `path/to/a` because `a` might be a directory
 	if pattern == "" ||
@@ -350,18 +350,18 @@ func isZeroLengthPattern(pattern string, separator rune) (ret bool, err error) {
 			}
 			commaIdx += patIdx
 
-			ret, err = isZeroLengthPattern(pattern[patIdx:commaIdx]+pattern[closingIdx+1:], separator)
+			ret, err = isZeroLengthPattern(pattern[patIdx:commaIdx]+pattern[closingIdx+1:], separator, validate)
 			if ret || err != nil {
 				return
 			}
 
 			patIdx = commaIdx + 1
 		}
-		return isZeroLengthPattern(pattern[patIdx:closingIdx]+pattern[closingIdx+1:], separator)
+		return isZeroLengthPattern(pattern[patIdx:closingIdx]+pattern[closingIdx+1:], separator, validate)
 	}
 
 	// no luck - validate the rest of the pattern
-	if !doValidatePattern(pattern, separator) {
+	if validate && !doValidatePattern(pattern, separator) {
 		return false, ErrBadPattern
 	}
 	return false, nil


### PR DESCRIPTION
## What

Right now, the code skips validating the end of the pattern in MatchUnvalidated() if it finds that pattern has not matched. However, if we get to the end of the name and there is still pattern that is not "zero length", we don't need to validate that either.

Also add some unit tests to make sure we are skipping validation when we can.

## Why

Speed up the code a bit by skipping more unnecessary validation.

## Tests

I added a unit test specifically to see what errors are being detected whether validate is set to true or false.

When those tests are run on main, they show a single error:
```
    doublestar_test.go:304: #2. Unvalidated error of Match(`a[`, `a`) = syntax error in pattern want <nil>
```

This is capturing the fact that we got to the end of the name, had matched the whole way, but were unnecessarily doing additional validation instead of immediately returning false.