### PR TITLE
Remove unreachable code in match

### DIFF
--- a/match.go
+++ b/match.go
@@ -311,11 +311,6 @@ MATCH:
 		return false, nil
 	}
 
-	if nameIdx < nameLen {
-		// we reached the end of `pattern` before the end of `name`
-		return false, nil
-	}
-
 	// we've reached the end of `name`; we've successfully matched if we've also
 	// reached the end of `pattern`, or if the rest of `pattern` can match a
 	// zero-length string


### PR DESCRIPTION
## What

Remove an if statement that is never entered

## Why

Dead code, it's very simple so not much of a performance improvement, removing it just aids in readability.

The main `for` loop has the same condition as this if statement, and there are no breaks in the for loop itself. If we do leave the for loop its done because the condition is false, so there's no reason to check the condition.

## Testing

I added a `panic()` to the if statement and ran the tests, and they still all passed, indicating to me the loop was never entered.